### PR TITLE
Rotate stirrups with structure

### DIFF
--- a/Stirrup.py
+++ b/Stirrup.py
@@ -227,18 +227,16 @@ def makeStirrup(l_cover, r_cover, t_cover, b_cover, f_cover, bentAngle, bentFact
     points = getpointsOfStirrup(FacePRM, l_cover, r_cover, t_cover, b_cover, bentAngle, bentFactor, diameter, rounding, FaceNormal)
     import Draft
     line = Draft.makeWire(points, closed = False, face = True, support = None)
-
-    # Rotate Stirrups with Structure
-    structureAngle = math.degrees(structure.Placement.Rotation.Angle)
-    structureAngle = structureAngle % 360
-    if 30 < structureAngle < 150 or 210 < structureAngle <= 330:
-        wireAngle = structureAngle - 90
-    else:
-        wireAngle = structureAngle
-    line.Placement.Rotation.Angle = math.radians(wireAngle)
-
     import Arch
     line.Support = [(structure, facename)]
+
+    # Rotate Stirrups with Column
+    if structure.IfcRole == "Column":
+        line.MapMode = "FlatFace"
+        elevation = line.Placement.Base.z
+        if elevation is not 0:
+            line.AttachmentOffset.Base.z -= elevation
+
     if amount_spacing_check:
         rebar = Arch.makeRebar(structure, line, diameter, amount_spacing_value, f_cover)
     else:
@@ -332,16 +330,6 @@ def editStirrup(Rebar, l_cover, r_cover, t_cover, b_cover, f_cover, bentAngle, b
     Rebar.TopCover = t_cover
     Rebar.BottomCover = b_cover
     Rebar.TrueSpacing = amount_spacing_value
-
-    # Rotate Stirrups with Structure
-    structureAngle = math.degrees(structure.Placement.Rotation.Angle)
-    structureAngle = structureAngle % 360
-    if 30 < structureAngle < 150 or 210 < structureAngle <= 330:
-        wireAngle = structureAngle - 90
-    else:
-        wireAngle = structureAngle
-    Rebar.Base.Placement.Rotation.Angle = math.radians(wireAngle)
-
     FreeCAD.ActiveDocument.recompute()
     return Rebar
 

--- a/Stirrup.py
+++ b/Stirrup.py
@@ -227,6 +227,16 @@ def makeStirrup(l_cover, r_cover, t_cover, b_cover, f_cover, bentAngle, bentFact
     points = getpointsOfStirrup(FacePRM, l_cover, r_cover, t_cover, b_cover, bentAngle, bentFactor, diameter, rounding, FaceNormal)
     import Draft
     line = Draft.makeWire(points, closed = False, face = True, support = None)
+
+    # Rotate Stirrups with Structure
+    structureAngle = math.degrees(structure.Placement.Rotation.Angle)
+    structureAngle = structureAngle % 360
+    if 30 < structureAngle < 150 or 210 < structureAngle <= 330:
+        wireAngle = structureAngle - 90
+    else:
+        wireAngle = structureAngle
+    line.Placement.Rotation.Angle = math.radians(wireAngle)
+
     import Arch
     line.Support = [(structure, facename)]
     if amount_spacing_check:
@@ -237,14 +247,6 @@ def makeStirrup(l_cover, r_cover, t_cover, b_cover, f_cover, bentAngle, bentFact
             int((size - diameter) / amount_spacing_value), f_cover)
     rebar.Direction = FaceNormal.negative()
     rebar.Rounding = rounding
-
-    # Rotate Stirrups with Structure
-    structureAngle = math.degrees(structure.Placement.Rotation.Angle)
-    if structureAngle in (0.0, 180.0,):
-        stirrupAngle = structureAngle
-    else:
-        stirrupAngle = structureAngle - 90
-    rebar.Placement.Rotation.Angle = math.radians(stirrupAngle)
 
     # Adds properties to the rebar object
     rebar.ViewObject.addProperty("App::PropertyString", "RebarShape", "RebarDialog",\
@@ -333,11 +335,12 @@ def editStirrup(Rebar, l_cover, r_cover, t_cover, b_cover, f_cover, bentAngle, b
 
     # Rotate Stirrups with Structure
     structureAngle = math.degrees(structure.Placement.Rotation.Angle)
-    if structureAngle in (0.0, 180.0,):
-        stirrupAngle = structureAngle
+    structureAngle = structureAngle % 360
+    if 30 < structureAngle < 150 or 210 < structureAngle <= 330:
+        wireAngle = structureAngle - 90
     else:
-        stirrupAngle = structureAngle - 90
-    Rebar.Placement.Rotation.Angle = math.radians(stirrupAngle)
+        wireAngle = structureAngle
+    Rebar.Base.Placement.Rotation.Angle = math.radians(wireAngle)
 
     FreeCAD.ActiveDocument.recompute()
     return Rebar

--- a/Stirrup.py
+++ b/Stirrup.py
@@ -237,6 +237,15 @@ def makeStirrup(l_cover, r_cover, t_cover, b_cover, f_cover, bentAngle, bentFact
             int((size - diameter) / amount_spacing_value), f_cover)
     rebar.Direction = FaceNormal.negative()
     rebar.Rounding = rounding
+
+    # Rotate Stirrups with Structure
+    structureAngle = math.degrees(structure.Placement.Rotation.Angle)
+    if structureAngle in {0.0, 180.0}:
+        stirrupAngle = structureAngle
+    else:
+        stirrupAngle = structureAngle - 90
+    rebar.Placement.Rotation.__setattr__("Angle", math.radians(stirrupAngle))
+
     # Adds properties to the rebar object
     rebar.ViewObject.addProperty("App::PropertyString", "RebarShape", "RebarDialog",\
         QT_TRANSLATE_NOOP("App::Property","Shape of rebar")).RebarShape = "Stirrup"
@@ -321,6 +330,15 @@ def editStirrup(Rebar, l_cover, r_cover, t_cover, b_cover, f_cover, bentAngle, b
     Rebar.TopCover = t_cover
     Rebar.BottomCover = b_cover
     Rebar.TrueSpacing = amount_spacing_value
+
+    # Rotate Stirrups with Structure
+    structureAngle = math.degrees(structure.Placement.Rotation.Angle)
+    if structureAngle in {0.0, 180.0}:
+        stirrupAngle = structureAngle
+    else:
+        stirrupAngle = structureAngle - 90
+    Rebar.Placement.Rotation.__setattr__("Angle", math.radians(stirrupAngle))
+
     FreeCAD.ActiveDocument.recompute()
     return Rebar
 

--- a/Stirrup.py
+++ b/Stirrup.py
@@ -240,11 +240,11 @@ def makeStirrup(l_cover, r_cover, t_cover, b_cover, f_cover, bentAngle, bentFact
 
     # Rotate Stirrups with Structure
     structureAngle = math.degrees(structure.Placement.Rotation.Angle)
-    if structureAngle in {0.0, 180.0}:
+    if structureAngle in (0.0, 180.0,):
         stirrupAngle = structureAngle
     else:
         stirrupAngle = structureAngle - 90
-    rebar.Placement.Rotation.__setattr__("Angle", math.radians(stirrupAngle))
+    rebar.Placement.Rotation.Angle = math.radians(stirrupAngle)
 
     # Adds properties to the rebar object
     rebar.ViewObject.addProperty("App::PropertyString", "RebarShape", "RebarDialog",\
@@ -333,11 +333,11 @@ def editStirrup(Rebar, l_cover, r_cover, t_cover, b_cover, f_cover, bentAngle, b
 
     # Rotate Stirrups with Structure
     structureAngle = math.degrees(structure.Placement.Rotation.Angle)
-    if structureAngle in {0.0, 180.0}:
+    if structureAngle in (0.0, 180.0,):
         stirrupAngle = structureAngle
     else:
         stirrupAngle = structureAngle - 90
-    Rebar.Placement.Rotation.__setattr__("Angle", math.radians(stirrupAngle))
+    Rebar.Placement.Rotation.Angle = math.radians(stirrupAngle)
 
     FreeCAD.ActiveDocument.recompute()
     return Rebar


### PR DESCRIPTION
Add functionality to rotate Stirrups with Structure
Code snippet:
structureAngle = math.degrees(structure.Placement.Rotation.Angle)
if structureAngle in {0.0, 180.0}:
    stirrupAngle = structureAngle
else:
    stirrupAngle = structureAngle - 90
rebar.Placement.Rotation.__setattr__("Angle", math.radians(stirrupAngle))

Illustration:
Before this code:
if column makes angle, say 45 degree, with x-axis and top view of column looks like:

![TopViewBefore1](https://user-images.githubusercontent.com/40318315/56098390-bb258780-5f1d-11e9-8d0f-eed528dcf304.png)

And we create stirrups by selecting top face of column, then top view of column is:

![image](https://user-images.githubusercontent.com/40318315/56098465-73533000-5f1e-11e9-90f4-7005edba136b.png)


**After using this code:**

![image](https://user-images.githubusercontent.com/40318315/56098525-d80e8a80-5f1e-11e9-83a7-101ee4c83516.png)
