### PR TITLE
README: fix typos, markdown and grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,20 @@ This project is aimed at easing up the process of rebaring in [FreeCAD](https://
 - FreeCAD (version >= 0.17): [Installation guide](https://www.freecadweb.org/wiki/Installing)
  
 ### Steps to install Rebar Addon in FreeCAD
-1. Open the FreeCAD Addon Manager (```Tool -> Addon manager```).
-2. When an addon manager will open, select ```Reinforcement``` from a list of workbenches shown by an addon manager.
-3. After selecting, click on ```Install/Update``` button.
+1. Open the FreeCAD Addon Manager (`Tool -> Addon manager`).
+2. Within the Addon Manager select `Reinforcement` from a list of the workbenches shown.
+3. After selecting, click on the `Install/Update` button.
 4. Restart FreeCAD.
-5. Now you will see different rebars in a drop-down list of rebar tools (```Arch -> Rebar tools -> Different rebars```).
+5. Now you will see different rebars in a drop-down list of rebar tools (`Arch -> Rebar tools -> Different rebars`).
 
 ## How it works
-Each rebar tool has two files, one is ```Python``` file and second is there respective name ```UI``` file like ```StraightRebar.py``` and ```StraightRebar.ui``` file). Let's take a straight rebar tool. In ```StraightRebar.py``` file, there are two functions. One is ```makeStraightRebar()``` function. This function creates straight rebar and adds new properties to the default ```Rebar``` object. Second function is ```editStraightRebar```. This function is used when we want to change a new properties(which is created by ```makeStraightRebar``` function) of the rebar object and it will take ```Rebar``` object as input which is created by ```makeStraightRebar``` function. In ```StraightRebar.py```, ```_StraightRebarTaskPanel``` class is present. This class loads UI(present in ```StriaghtRebar.ui``` file) in the task panel of FreeCAD. First time when a user clicks on ```Apply``` or ```Ok``` button, then ```makeStraightRebar``` function is executed and after that when user want to change the properties of Straight rebar then ```editStraightRebar``` function is excuted. 
+Each rebar tool has two files, one is the `Python` file and the second is there respective name `UI` file like `StraightRebar.py` and `StraightRebar.ui` file. 
+Let's take a straight rebar tool. In `StraightRebar.py` file, there are two functions. One is the `makeStraightRebar()` function. 
+This function creates straight rebar and adds new properties to the default `Rebar` object. The second function is `editStraightRebar`. 
+This function is used when we want to change a new properties (which is created by the `makeStraightRebar` function) of the rebar object and it will take the 
+`Rebar` object as input which is created by the `makeStraightRebar` function. In `StraightRebar.py`, `_StraightRebarTaskPanel` class is present. 
+This class loads the UI (present in `StraightRebar.ui` file) in the task panel of FreeCAD. The first time a user clicks on `Apply` or the `Ok` button the 
+`makeStraightRebar` function is executed. After that when the user wants to change the properties of Straight rebar then the `editStraightRebar` function is executed. 
 
 ## Extras
 - [FreeCAD forum thread](https://forum.freecadweb.org/viewtopic.php?f=8&t=22760)


### PR DESCRIPTION
JFYI some markdown notes:  
* ```test``` is the same as `test` but better to use for multiline blocks.   
* If the end of a sentence is not terminated with 2 whitespace chars then markdown will ignore the newline. I edited the 'How it works' section to be more readable in a text editor but in the README, it hasn't changed.
 