### PR TITLE
Remove self from closeDialog parameters, fixes #111

### DIFF
--- a/BentShapeRebar.py
+++ b/BentShapeRebar.py
@@ -341,7 +341,7 @@ class _BentShapeRebarTaskPanel:
         if signal == int(QtGui.QDialogButtonBox.Apply):
             pass
         else:
-            FreeCADGui.Control.closeDialog(self)
+            FreeCADGui.Control.closeDialog()
 
     def amount_radio_clicked(self):
         self.form.spacing.setEnabled(False)

--- a/HelicalRebar.py
+++ b/HelicalRebar.py
@@ -256,7 +256,7 @@ class _HelicalRebarTaskPanel:
         if signal == int(QtGui.QDialogButtonBox.Apply):
             pass
         else:
-            FreeCADGui.Control.closeDialog(self)
+            FreeCADGui.Control.closeDialog()
 
 
 def makeHelicalRebar(

--- a/LShapeRebar.py
+++ b/LShapeRebar.py
@@ -285,7 +285,7 @@ class _LShapeRebarTaskPanel:
         if signal == int(QtGui.QDialogButtonBox.Apply):
             pass
         else:
-            FreeCADGui.Control.closeDialog(self)
+            FreeCADGui.Control.closeDialog()
 
     def amount_radio_clicked(self):
         self.form.spacing.setEnabled(False)

--- a/Stirrup.py
+++ b/Stirrup.py
@@ -339,7 +339,7 @@ class _StirrupTaskPanel:
         if signal == int(QtGui.QDialogButtonBox.Apply):
             pass
         else:
-            FreeCADGui.Control.closeDialog(self)
+            FreeCADGui.Control.closeDialog()
 
     def amount_radio_clicked(self):
         self.form.spacing.setEnabled(False)

--- a/StraightRebar.py
+++ b/StraightRebar.py
@@ -277,7 +277,7 @@ class _StraightRebarTaskPanel:
         if signal == int(QtGui.QDialogButtonBox.Apply):
             pass
         else:
-            FreeCADGui.Control.closeDialog(self)
+            FreeCADGui.Control.closeDialog()
 
     def amount_radio_clicked(self):
         self.form.spacing.setEnabled(False)

--- a/UShapeRebar.py
+++ b/UShapeRebar.py
@@ -296,7 +296,7 @@ class _UShapeRebarTaskPanel:
         if signal == int(QtGui.QDialogButtonBox.Apply):
             pass
         else:
-            FreeCADGui.Control.closeDialog(self)
+            FreeCADGui.Control.closeDialog()
 
     def amount_radio_clicked(self):
         self.form.spacing.setEnabled(False)


### PR DESCRIPTION
Due to changes in FreeCAD master branch, `closeDialog` does not needs the `self` parameter anymore and in fact that raises a `TypeError`. So this PR resolves that.