### PR TITLE
Fix typing.Literal import for python < 3.8

### DIFF
--- a/BarBendingSchedule/BBSfunc.py
+++ b/BarBendingSchedule/BBSfunc.py
@@ -28,7 +28,6 @@ __url__ = "https://www.freecadweb.org"
 from typing import (
     Dict,
     List,
-    Literal,
     Optional,
     OrderedDict as OrderedDictType,
     Tuple,
@@ -54,29 +53,36 @@ from RebarShapeCutList.RebarShapeCutListfunc import (
 from SVGfunc import getSVGRootElement, getSVGRectangle, getSVGDataCell
 
 
+# TODO: Use(Uncomment) typing.Literal for minimum python3.8
+
+
 def getBarBendingSchedule(
     rebar_objects: Optional[List] = None,
-    column_headers: Optional[
-        OrderedDictType[
-            Literal[
-                "Host",
-                "Mark",
-                "RebarsCount",
-                "Diameter",
-                "RebarLength",
-                "RebarsTotalLength",
-            ],
-            str,
-        ]
-    ] = None,
-    column_units: Optional[
-        Dict[Literal["Diameter", "RebarLength", "RebarsTotalLength"], str]
-    ] = None,
+    # column_headers: Optional[
+    #     OrderedDictType[
+    #         Literal[
+    #             "Host",
+    #             "Mark",
+    #             "RebarsCount",
+    #             "Diameter",
+    #             "RebarLength",
+    #             "RebarsTotalLength",
+    #         ],
+    #         str,
+    #     ]
+    # ] = None,
+    column_headers: Optional[OrderedDictType[str, str]] = None,
+    # column_units: Optional[
+    #     Dict[Literal["Diameter", "RebarLength", "RebarsTotalLength"], str]
+    # ] = None,
+    column_units: Optional[Dict[str, str]] = None,
     dia_weight_map: Optional[Dict[float, FreeCAD.Units.Quantity]] = None,
-    rebar_length_type: Optional[
-        Literal["RealLength", "LengthWithSharpEdges"]
-    ] = None,
-    reinforcement_group_by: Optional[Literal["Mark", "Host"]] = None,
+    # rebar_length_type: Optional[
+    #     Literal["RealLength", "LengthWithSharpEdges"]
+    # ] = None,
+    rebar_length_type: Optional[str] = None,
+    # reinforcement_group_by: Optional[Literal["Mark", "Host"]] = None,
+    reinforcement_group_by: Optional[str] = None,
     font_family: Optional[str] = None,
     font_size: float = 5,
     column_width: float = 60,

--- a/BarBendingSchedule/MainBarBendingSchedule.py
+++ b/BarBendingSchedule/MainBarBendingSchedule.py
@@ -29,7 +29,6 @@ from collections import OrderedDict
 from pathlib import Path
 from typing import (
     Dict,
-    Literal,
     Optional,
     OrderedDict as OrderedDictType,
     Tuple,
@@ -48,27 +47,34 @@ from BillOfMaterial.config import COLUMN_HEADERS
 from .BBSfunc import getBarBendingSchedule
 
 
+# TODO: Use(Uncomment) typing.Literal for minimum python3.8
+
+
 class _BarBendingScheduleDialog:
     """This is a class for Bar Bending Schedule dialog box."""
 
     def __init__(
         self,
-        column_headers: OrderedDictType[
-            Literal[
-                "Host",
-                "Mark",
-                "RebarsCount",
-                "Diameter",
-                "RebarLength",
-                "RebarsTotalLength",
-            ],
-            str,
-        ],
-        column_units: Dict[
-            Literal["Diameter", "RebarLength", "RebarsTotalLength"], str
-        ],
-        rebar_length_type: Literal["RealLength", "LengthWithSharpEdges"],
-        reinforcement_group_by: Literal["Mark", "Host"],
+        # column_headers: OrderedDictType[
+        #     Literal[
+        #         "Host",
+        #         "Mark",
+        #         "RebarsCount",
+        #         "Diameter",
+        #         "RebarLength",
+        #         "RebarsTotalLength",
+        #     ],
+        #     str,
+        # ],
+        column_headers: OrderedDictType[str, str],
+        # column_units: Dict[
+        #     Literal["Diameter", "RebarLength", "RebarsTotalLength"], str
+        # ],
+        column_units: Dict[str, str],
+        # rebar_length_type: Literal["RealLength", "LengthWithSharpEdges"],
+        rebar_length_type: str,
+        # reinforcement_group_by: Literal["Mark", "Host"],
+        reinforcement_group_by: str,
         font_family: str,
         font_size: float,
         column_width: float,
@@ -447,17 +453,18 @@ class _BarBendingScheduleDialog:
 
     def getColumnConfigData(
         self,
-    ) -> OrderedDictType[
-        Literal[
-            "Host",
-            "Mark",
-            "RebarsCount",
-            "Diameter",
-            "RebarLength",
-            "RebarsTotalLength",
-        ],
-        str,
-    ]:
+        # ) -> OrderedDictType[
+        #     Literal[
+        #         "Host",
+        #         "Mark",
+        #         "RebarsCount",
+        #         "Diameter",
+        #         "RebarLength",
+        #         "RebarsTotalLength",
+        #     ],
+        #     str,
+        # ]:
+    ) -> OrderedDictType[str, str]:
         """This function get data from UI and return an ordered dictionary with
         column data as key and column display header as value.
         e.g. {
@@ -488,26 +495,30 @@ class _BarBendingScheduleDialog:
 
 
 def CommandBarBendingSchedule(
-    column_headers: Optional[
-        OrderedDictType[
-            Literal[
-                "Host",
-                "Mark",
-                "RebarsCount",
-                "Diameter",
-                "RebarLength",
-                "RebarsTotalLength",
-            ],
-            str,
-        ]
-    ] = None,
-    column_units: Optional[
-        Dict[Literal["Diameter", "RebarLength", "RebarsTotalLength"], str]
-    ] = None,
-    rebar_length_type: Optional[
-        Literal["RealLength", "LengthWithSharpEdges"]
-    ] = None,
-    reinforcement_group_by: Optional[Literal["Mark", "Host"]] = None,
+    # column_headers: Optional[
+    #     OrderedDictType[
+    #         Literal[
+    #             "Host",
+    #             "Mark",
+    #             "RebarsCount",
+    #             "Diameter",
+    #             "RebarLength",
+    #             "RebarsTotalLength",
+    #         ],
+    #         str,
+    #     ]
+    # ] = None,
+    column_headers: Optional[OrderedDictType[str, str]] = None,
+    # column_units: Optional[
+    #     Dict[Literal["Diameter", "RebarLength", "RebarsTotalLength"], str]
+    # ] = None,
+    column_units: Optional[Dict[str, str]] = None,
+    # rebar_length_type: Optional[
+    #     Literal["RealLength", "LengthWithSharpEdges"]
+    # ] = None,
+    rebar_length_type: Optional[str] = None,
+    # reinforcement_group_by: Optional[Literal["Mark", "Host"]] = None,
+    reinforcement_group_by: Optional[str] = None,
     font_family: Optional[str] = None,
     font_size: float = 5,
     column_width: float = 60,

--- a/BentShapeRebar.py
+++ b/BentShapeRebar.py
@@ -27,7 +27,7 @@ __url__ = "https://www.freecadweb.org"
 
 import math
 from pathlib import Path
-from typing import Literal, Tuple, List
+from typing import Tuple, List
 
 import ArchCommands
 import FreeCAD
@@ -48,6 +48,9 @@ from Rebarfunc import (
 )
 
 
+# TODO: Use(Uncomment) typing.Literal for minimum python3.8
+
+
 def getpointsOfBentShapeRebar(
     FacePRM: Tuple[Tuple[float, float], Tuple[float, float]],
     l_cover: float,
@@ -56,7 +59,8 @@ def getpointsOfBentShapeRebar(
     t_cover: float,
     bentLength: float,
     bentAngle: float,
-    orientation: Literal["Bottom", "Top", "Left", "Right"],
+    # orientation: Literal["Bottom", "Top", "Left", "Right"],
+    orientation: str,
     diameter: float,
     face_normal: FreeCAD.Vector,
 ) -> List[FreeCAD.Vector]:

--- a/BillOfMaterial/BOMPreferences.py
+++ b/BillOfMaterial/BOMPreferences.py
@@ -28,7 +28,7 @@ __url__ = "https://www.freecadweb.org"
 
 from collections import OrderedDict
 from pathlib import Path
-from typing import Dict, Literal, OrderedDict as OrderedDictType, Union
+from typing import Dict, OrderedDict as OrderedDictType, Union
 
 import FreeCAD
 
@@ -53,32 +53,39 @@ from .config import (
 )
 
 
+# TODO: Use(Uncomment) typing.Literal for minimum python3.8
+
+
 class BOMPreferences:
     def __init__(
         self,
-        conf_column_units: Dict[
-            Literal["Diameter", "RebarLength", "RebarsTotalLength"], str
-        ] = COLUMN_UNITS,
-        conf_column_headers: OrderedDictType[
-            Literal[
-                "Host",
-                "Mark",
-                "RebarsCount",
-                "Diameter",
-                "RebarLength",
-                "RebarsTotalLength",
-            ],
-            str,
-        ] = COLUMN_HEADERS,
+        # conf_column_units: Dict[
+        #     Literal["Diameter", "RebarLength", "RebarsTotalLength"], str
+        # ] = COLUMN_UNITS,
+        conf_column_units: Dict[str, str] = COLUMN_UNITS,
+        # conf_column_headers: OrderedDictType[
+        #     Literal[
+        #         "Host",
+        #         "Mark",
+        #         "RebarsCount",
+        #         "Diameter",
+        #         "RebarLength",
+        #         "RebarsTotalLength",
+        #     ],
+        #     str,
+        # ] = COLUMN_HEADERS,
+        conf_column_headers: OrderedDictType[str, str] = COLUMN_HEADERS,
         conf_dia_weight_map: Dict[
             float, FreeCAD.Units.Quantity
         ] = DIA_WEIGHT_MAP,
-        conf_rebar_length_type: Literal[
-            "RealLength", "LengthWithSharpEdges"
-        ] = REBAR_LENGTH_TYPE,
-        conf_reinforcement_group_by: Literal[
-            "Mark", "Host"
-        ] = REINFORCEMENT_GROUP_BY,
+        # conf_rebar_length_type: Literal[
+        #     "RealLength", "LengthWithSharpEdges"
+        # ] = REBAR_LENGTH_TYPE,
+        conf_rebar_length_type: str = REBAR_LENGTH_TYPE,
+        # conf_reinforcement_group_by: Literal[
+        #     "Mark", "Host"
+        # ] = REINFORCEMENT_GROUP_BY,
+        conf_reinforcement_group_by: str = REINFORCEMENT_GROUP_BY,
         conf_column_width: float = COLUMN_WIDTH,
         conf_row_height: float = ROW_HEIGHT,
         conf_font_family: str = FONT_FAMILY,
@@ -307,7 +314,8 @@ class BOMPreferences:
 
     def getColumnUnits(
         self,
-    ) -> Dict[Literal["Diameter", "RebarLength", "RebarsTotalLength"], str]:
+        # ) -> Dict[Literal["Diameter", "RebarLength", "RebarsTotalLength"], str]:
+    ) -> Dict[str, str]:
         column_units = {}
         for column in self.column_units.GetStrings():
             units = self.column_units.GetString(column)
@@ -316,17 +324,18 @@ class BOMPreferences:
 
     def getColumnHeaders(
         self,
-    ) -> OrderedDictType[
-        Literal[
-            "Host",
-            "Mark",
-            "RebarsCount",
-            "Diameter",
-            "RebarLength",
-            "RebarsTotalLength",
-        ],
-        str,
-    ]:
+        # ) -> OrderedDictType[
+        #     Literal[
+        #         "Host",
+        #         "Mark",
+        #         "RebarsCount",
+        #         "Diameter",
+        #         "RebarLength",
+        #         "RebarsTotalLength",
+        #     ],
+        #     str,
+        # ]:
+    ) -> OrderedDictType[str, str]:
         columns = []
         for column in self.column_headers.GetGroups():
             header = self.column_headers.GetGroup(column)
@@ -349,7 +358,8 @@ class BOMPreferences:
 
     def getRebarLengthType(
         self,
-    ) -> Literal["RealLength", "LengthWithSharpEdges"]:
+        # ) -> Literal["RealLength", "LengthWithSharpEdges"]:
+    ) -> str:
         rebar_length_type = self.available_rebar_length_types[
             self.bom_pref.GetInt(
                 "RebarLengthType",
@@ -360,7 +370,8 @@ class BOMPreferences:
         ]
         return rebar_length_type
 
-    def getReinforcementGroupBy(self) -> Literal["Mark", "Host"]:
+    # def getReinforcementGroupBy(self) -> Literal["Mark", "Host"]:
+    def getReinforcementGroupBy(self) -> str:
         reinforcement_group_by = self.available_reinforcement_group_by[
             self.bom_pref.GetInt(
                 "ReinforcementGroupBy",

--- a/BillOfMaterial/BOMfunc.py
+++ b/BillOfMaterial/BOMfunc.py
@@ -25,11 +25,14 @@ __title__ = "Bill Of Material Helper Functions"
 __author__ = "Suraj"
 __url__ = "https://www.freecadweb.org"
 
-from typing import Dict, Optional, List, Literal
+from typing import Dict, Optional, List
+
+import Draft
+import FreeCAD
 from PySide2 import QtGui
 
-import FreeCAD
-import Draft
+
+# TODO: Use(Uncomment) typing.Literal for minimum python3.8
 
 
 def getBaseRebar(reinforcement_obj):
@@ -257,7 +260,8 @@ def getRebarSharpEdgedLength(rebar):
 
 def fixColumnUnits(
     column_units: Dict[str, str]
-) -> Dict[Literal["Diameter", "RebarLength", "RebarsTotalLength"], str]:
+    # ) -> Dict[Literal["Diameter", "RebarLength", "RebarsTotalLength"], str]:
+) -> Dict[str, str]:
     """Add missing units data to column_units dictionary.
 
     Parameters

--- a/BillOfMaterial/BillOfMaterial_SVG.py
+++ b/BillOfMaterial/BillOfMaterial_SVG.py
@@ -28,7 +28,6 @@ __url__ = "https://www.freecadweb.org"
 from typing import (
     Optional,
     Dict,
-    Literal,
     List,
     OrderedDict as OrderedDictType,
     Union,
@@ -55,6 +54,9 @@ from .BOMfunc import (
     getBaseRebar,
 )
 from .BillOfMaterialContent import makeBOMObject
+
+
+# TODO: Use(Uncomment) typing.Literal for minimum python3.8
 
 
 def getColumnNumber(column_headers, diameter_list, column_header):
@@ -177,26 +179,29 @@ def getColumnHeadersSVG(
 
 
 def makeBillOfMaterialSVG(
-    column_headers: Optional[
-        OrderedDictType[
-            Literal[
-                "Host",
-                "Mark",
-                "RebarsCount",
-                "Diameter",
-                "RebarLength",
-                "RebarsTotalLength",
-            ],
-            str,
-        ]
-    ] = None,
-    column_units: Optional[
-        Dict[Literal["Diameter", "RebarLength", "RebarsTotalLength"], str]
-    ] = None,
+    # column_headers: Optional[
+    #     OrderedDictType[
+    #         Literal[
+    #             "Host",
+    #             "Mark",
+    #             "RebarsCount",
+    #             "Diameter",
+    #             "RebarLength",
+    #             "RebarsTotalLength",
+    #         ],
+    #         str,
+    #     ]
+    # ] = None,
+    column_headers: Optional[OrderedDictType[str, str]] = None,
+    # column_units: Optional[
+    #     Dict[Literal["Diameter", "RebarLength", "RebarsTotalLength"], str]
+    # ] = None,
+    column_units: Optional[Dict[str, str]] = None,
     dia_weight_map: Optional[Dict[float, FreeCAD.Units.Quantity]] = None,
-    rebar_length_type: Optional[
-        Literal["RealLength", "LengthWithSharpEdges"]
-    ] = None,
+    # rebar_length_type: Optional[
+    #     Literal["RealLength", "LengthWithSharpEdges"]
+    # ] = None,
+    rebar_length_type: Optional[str] = None,
     font_family: Optional[str] = None,
     font_filename: Optional[str] = None,
     font_size: Optional[float] = None,
@@ -211,7 +216,8 @@ def makeBillOfMaterialSVG(
     template_file: Optional[str] = None,
     output_file: Optional[str] = None,
     rebar_objects: Optional[List] = None,
-    reinforcement_group_by: Optional[Literal["Mark", "Host"]] = None,
+    # reinforcement_group_by: Optional[Literal["Mark", "Host"]] = None,
+    reinforcement_group_by: Optional[str] = None,
     return_svg_only: bool = False,
 ):
     """makeBillOfMaterialSVG([ColumnHeaders, ColumnUnits, DiaWeightMap,

--- a/BillOfMaterial/BillOfMaterial_Spreadsheet.py
+++ b/BillOfMaterial/BillOfMaterial_Spreadsheet.py
@@ -28,7 +28,6 @@ __url__ = "https://www.freecadweb.org"
 from typing import (
     Optional,
     Dict,
-    Literal,
     List,
     OrderedDict as OrderedDictType,
     Union,
@@ -48,18 +47,22 @@ from .BOMfunc import (
 )
 
 
+# TODO: Use(Uncomment) typing.Literal for minimum python3.8
+
+
 def addSheetHeaders(
-    column_headers: OrderedDictType[
-        Literal[
-            "Host",
-            "Mark",
-            "RebarsCount",
-            "Diameter",
-            "RebarLength",
-            "RebarsTotalLength",
-        ],
-        str,
-    ],
+    # column_headers: OrderedDictType[
+    #     Literal[
+    #         "Host",
+    #         "Mark",
+    #         "RebarsCount",
+    #         "Diameter",
+    #         "RebarLength",
+    #         "RebarsTotalLength",
+    #     ],
+    #     str,
+    # ],
+    column_headers: OrderedDictType[str, str],
     diameter_list: List[FreeCAD.Units.Quantity],
     spreadsheet,
 ) -> None:
@@ -124,28 +127,32 @@ def getHeaderColumn(column_headers, diameter_list, column_header):
 
 
 def makeBillOfMaterial(
-    column_headers: Optional[
-        OrderedDictType[
-            Literal[
-                "Host",
-                "Mark",
-                "RebarsCount",
-                "Diameter",
-                "RebarLength",
-                "RebarsTotalLength",
-            ],
-            str,
-        ]
-    ] = None,
-    column_units: Optional[
-        Dict[Literal["Diameter", "RebarLength", "RebarsTotalLength"], str]
-    ] = None,
+    # column_headers: Optional[
+    #     OrderedDictType[
+    #         Literal[
+    #             "Host",
+    #             "Mark",
+    #             "RebarsCount",
+    #             "Diameter",
+    #             "RebarLength",
+    #             "RebarsTotalLength",
+    #         ],
+    #         str,
+    #     ]
+    # ] = None,
+    column_headers: Optional[OrderedDictType[str, str]] = None,
+    # column_units: Optional[
+    #     Dict[Literal["Diameter", "RebarLength", "RebarsTotalLength"], str]
+    # ] = None,
+    column_units: Optional[Dict[str, str]] = None,
     dia_weight_map: Optional[Dict[float, FreeCAD.Units.Quantity]] = None,
-    rebar_length_type: Optional[
-        Literal["RealLength", "LengthWithSharpEdges"]
-    ] = None,
+    # rebar_length_type: Optional[
+    #     Literal["RealLength", "LengthWithSharpEdges"]
+    # ] = None,
+    rebar_length_type: Optional[str] = None,
     rebar_objects: Optional[List] = None,
-    reinforcement_group_by: Optional[Literal["Mark", "Host"]] = None,
+    # reinforcement_group_by: Optional[Literal["Mark", "Host"]] = None,
+    reinforcement_group_by: Optional[str] = None,
     obj_name: str = "RebarBillOfMaterial",
 ):
     """makeBillOfMaterial(ColumnHeadersConfig, ColumnUnitsDict, DiaWeightMap,

--- a/BillOfMaterial/MainBillOfMaterial.py
+++ b/BillOfMaterial/MainBillOfMaterial.py
@@ -27,7 +27,7 @@ __url__ = "https://www.freecadweb.org"
 
 from collections import OrderedDict
 from pathlib import Path
-from typing import OrderedDict as OrderedDictType, Literal
+from typing import OrderedDict as OrderedDictType
 
 import FreeCAD
 import FreeCADGui
@@ -39,6 +39,9 @@ from .BillOfMaterial_SVG import makeBillOfMaterialSVG
 from .BillOfMaterial_Spreadsheet import makeBillOfMaterial
 from .UnitLineEdit import UnitLineEdit
 from .config import COLUMN_HEADERS
+
+
+# TODO: Use(Uncomment) typing.Literal for minimum python3.8
 
 
 class _BillOfMaterialDialog:
@@ -328,17 +331,18 @@ class _BillOfMaterialDialog:
 
     def getColumnConfigData(
         self,
-    ) -> OrderedDictType[
-        Literal[
-            "Host",
-            "Mark",
-            "RebarsCount",
-            "Diameter",
-            "RebarLength",
-            "RebarsTotalLength",
-        ],
-        str,
-    ]:
+        # ) -> OrderedDictType[
+        #     Literal[
+        #         "Host",
+        #         "Mark",
+        #         "RebarsCount",
+        #         "Diameter",
+        #         "RebarLength",
+        #         "RebarsTotalLength",
+        #     ],
+        #     str,
+        # ]:
+    ) -> OrderedDictType[str, str]:
         """This function get data from UI and return an ordered dictionary with
         column data as key and column display header as value.
         e.g. {

--- a/LShapeRebar.py
+++ b/LShapeRebar.py
@@ -26,7 +26,7 @@ __author__ = "Amritpal Singh"
 __url__ = "https://www.freecadweb.org"
 
 from pathlib import Path
-from typing import Tuple, Literal, List
+from typing import Tuple, List
 
 import ArchCommands
 import FreeCAD
@@ -47,15 +47,19 @@ from Rebarfunc import (
 )
 
 
+# TODO: Use(Uncomment) typing.Literal for minimum python3.8
+
+
 def getpointsOfLShapeRebar(
     FacePRM: Tuple[Tuple[float, float], Tuple[float, float]],
     l_cover: float,
     r_cover: float,
     b_cover: float,
     t_cover: float,
-    orientation: Literal[
-        "Bottom Left", "Bottom Right", "Top Left", "Top Right"
-    ],
+    # orientation: Literal[
+    #     "Bottom Left", "Bottom Right", "Top Left", "Top Right"
+    # ],
+    orientation: str,
     diameter: float,
     face_normal: FreeCAD.Vector,
 ) -> List[FreeCAD.Vector]:

--- a/RebarShapeCutList/MainRebarShapeCutList.py
+++ b/RebarShapeCutList/MainRebarShapeCutList.py
@@ -26,7 +26,7 @@ __author__ = "Suraj"
 __url__ = "https://www.freecadweb.org"
 
 from pathlib import Path
-from typing import Tuple, Union, List, Literal
+from typing import Tuple, Union, List
 
 import Draft
 import FreeCAD
@@ -42,6 +42,9 @@ from RebarShapeCutList.RebarShapeCutListfunc import (
 )
 
 
+# TODO: Use(Uncomment) typing.Literal for minimum python3.8
+
+
 class _RebarShapeCutListDialog:
     """A Rebar Shape Cut List dialog box"""
 
@@ -52,7 +55,8 @@ class _RebarShapeCutListDialog:
         rebars_color_style: str,
         row_height: float,
         column_width: float,
-        column_count: Union[int, Literal["row_count"]],
+        # column_count: Union[int, Literal["row_count"]],
+        column_count: Union[int, str],
         side_padding: float,
         horizontal_rebar_shape: bool,
         include_mark: bool,
@@ -306,7 +310,8 @@ def CommandRebarShapeCutList(
     rebars_color_style: str = "shape color",
     row_height: float = 40,
     column_width: float = 60,
-    column_count: Union[int, Literal["row_count"]] = "row_count",
+    # column_count: Union[int, Literal["row_count"]] = "row_count",
+    column_count: Union[int, str] = "row_count",
     side_padding: float = 1,
     horizontal_rebar_shape: bool = True,
     include_mark: bool = True,

--- a/RebarShapeCutList/RebarShapeCutListfunc.py
+++ b/RebarShapeCutList/RebarShapeCutListfunc.py
@@ -26,7 +26,7 @@ __author__ = "Suraj"
 __url__ = "https://www.freecadweb.org"
 
 import math
-from typing import Union, List, Tuple, Optional, Literal
+from typing import Union, List, Tuple, Optional
 from xml.dom import minidom
 from xml.etree import ElementTree
 
@@ -51,6 +51,9 @@ from SVGfunc import (
     getSVGTextElement,
     getSVGRectangle,
 )
+
+
+# TODO: Use(Uncomment) typing.Literal for minimum python3.8
 
 
 def getBaseRebarsList(
@@ -1024,7 +1027,8 @@ def getRebarShapeCutList(
     helical_rebar_dimension_label_format: str = "%L,r=%R,pitch=%P",
     row_height: float = 40,
     column_width: float = 60,
-    column_count: Union[int, Literal["row_count"]] = "row_count",
+    # column_count: Union[int, Literal["row_count"]] = "row_count",
+    column_count: Union[int, str] = "row_count",
     side_padding: float = 1,
     horizontal_rebar_shape: bool = True,
     output_file: Optional[str] = None,

--- a/ReinforcementDrawing/MainReinforcementDrawingDimensioning.py
+++ b/ReinforcementDrawing/MainReinforcementDrawingDimensioning.py
@@ -26,7 +26,7 @@ __author__ = "Suraj"
 __url__ = "https://www.freecadweb.org"
 
 from pathlib import Path
-from typing import Union, Literal, List, Tuple, Optional
+from typing import List, Tuple, Optional
 
 import FreeCAD
 import FreeCADGui
@@ -75,17 +75,23 @@ from .config import (
 )
 
 
+# TODO: Use(Uncomment) typing.Literal for minimum python3.8
+
+
 class _ReinforcementDrawingDimensioningDialog:
     """This is a class for Reinforcement Drawing Dimensioning dialog box."""
 
     def __init__(
         self,
-        views: List[Literal["Front", "Rear", "Left", "Right", "Top", "Bottom"]],
+        # views: List[Literal["Front", "Rear", "Left", "Right", "Top", "Bottom"]],
+        views: List[str],
         rebars_stroke_width: float,
-        rebars_color_style: Literal["Automatic", "Custom"],
+        # rebars_color_style: Literal["Automatic", "Custom"],
+        rebars_color_style: str,
         rebars_color: Tuple[float, float, float],
         structure_stroke_width: float,
-        structure_color_style: Literal["Automatic", "Custom", "None"],
+        # structure_color_style: Literal["Automatic", "Custom", "None"],
+        structure_color_style: str,
         structure_color: Tuple[float, float, float],
         drawing_left_offset: float,
         drawing_top_offset: float,
@@ -100,44 +106,50 @@ class _ReinforcementDrawingDimensioningDialog:
         dimension_font_family: str,
         dimension_font_size: float,
         dimension_stroke_width: float,
-        dimension_line_style: Literal[
-            "Continuous",
-            "Dash",
-            "Dot",
-            "DashDot",
-            "DashDotDot",
-        ],
+        # dimension_line_style: Literal[
+        #     "Continuous",
+        #     "Dash",
+        #     "Dot",
+        #     "DashDot",
+        #     "DashDotDot",
+        # ],
+        dimension_line_style: str,
         dimension_line_color: Tuple[float, float, float],
         dimension_text_color: Tuple[float, float, float],
-        dimension_single_rebar_line_start_symbol: Literal[
-            "FilledArrow",
-            "Tick",
-            "Dot",
-            "None",
-        ],
-        dimension_single_rebar_line_end_symbol: Literal[
-            "FilledArrow",
-            "Tick",
-            "Dot",
-            "None",
-        ],
-        dimension_multi_rebar_line_start_symbol: Literal[
-            "FilledArrow",
-            "Tick",
-            "Dot",
-            "None",
-        ],
-        dimension_multi_rebar_line_end_symbol: Literal[
-            "FilledArrow",
-            "Tick",
-            "Dot",
-            "None",
-        ],
-        dimension_line_mid_point_symbol: Literal[
-            "Tick",
-            "Dot",
-            "None",
-        ],
+        # dimension_single_rebar_line_start_symbol: Literal[
+        #     "FilledArrow",
+        #     "Tick",
+        #     "Dot",
+        #     "None",
+        # ],
+        dimension_single_rebar_line_start_symbol: str,
+        # dimension_single_rebar_line_end_symbol: Literal[
+        #     "FilledArrow",
+        #     "Tick",
+        #     "Dot",
+        #     "None",
+        # ],
+        dimension_single_rebar_line_end_symbol: str,
+        # dimension_multi_rebar_line_start_symbol: Literal[
+        #     "FilledArrow",
+        #     "Tick",
+        #     "Dot",
+        #     "None",
+        # ],
+        dimension_multi_rebar_line_start_symbol: str,
+        # dimension_multi_rebar_line_end_symbol: Literal[
+        #     "FilledArrow",
+        #     "Tick",
+        #     "Dot",
+        #     "None",
+        # ],
+        dimension_multi_rebar_line_end_symbol: str,
+        # dimension_line_mid_point_symbol: Literal[
+        #     "Tick",
+        #     "Dot",
+        #     "None",
+        # ],
+        dimension_line_mid_point_symbol: str,
         dimension_left_offset: float,
         dimension_right_offset: float,
         dimension_top_offset: float,
@@ -148,16 +160,18 @@ class _ReinforcementDrawingDimensioningDialog:
         dimension_bottom_offset_increment: float,
         dimension_single_rebar_outer_dim: bool,
         dimension_multi_rebar_outer_dim: bool,
-        dimension_single_rebar_text_position_type: Literal[
-            "MidOfLine",
-            "StartOfLine",
-            "EndOfLine",
-        ],
-        dimension_multi_rebar_text_position_type: Literal[
-            "MidOfLine",
-            "StartOfLine",
-            "EndOfLine",
-        ],
+        # dimension_single_rebar_text_position_type: Literal[
+        #     "MidOfLine",
+        #     "StartOfLine",
+        #     "EndOfLine",
+        # ],
+        dimension_single_rebar_text_position_type: str,
+        # dimension_multi_rebar_text_position_type: Literal[
+        #     "MidOfLine",
+        #     "StartOfLine",
+        #     "EndOfLine",
+        # ],
+        dimension_multi_rebar_text_position_type: str,
     ):
         """This function set initial data in Reinforcement Drawing Dimensioning
         dialog box."""
@@ -741,7 +755,8 @@ class _ReinforcementDrawingDimensioningDialog:
 
         def getFreeCADObjectsList(
             objects: list,
-        ) -> Union[Literal["None"], str]:
+            # ) -> Union[Literal["None"], str]:
+        ) -> str:
             return (
                 "None"
                 if not objects

--- a/StraightRebar.py
+++ b/StraightRebar.py
@@ -26,7 +26,7 @@ __author__ = "Amritpal Singh"
 __url__ = "https://www.freecadweb.org"
 
 from pathlib import Path
-from typing import Literal, Tuple, List
+from typing import Tuple, List
 
 import ArchCommands
 import FreeCAD
@@ -47,14 +47,19 @@ from Rebarfunc import (
 )
 
 
+# TODO: Use(Uncomment) typing.Literal for minimum python3.8
+
+
 def getpointsOfStraightRebar(
     FacePRM: Tuple[Tuple[float, float], Tuple[float, float]],
     rt_cover: float,
     lb_cover: float,
-    coverAlong: Tuple[
-        Literal["Bottom Side", "Top Side", "Left Side", "Right Side"], float
-    ],
-    orientation: Literal["Horizontal", "Vertical"],
+    # coverAlong: Tuple[
+    #     Literal["Bottom Side", "Top Side", "Left Side", "Right Side"], float
+    # ],
+    coverAlong: Tuple[str, float],
+    # orientation: Literal["Horizontal", "Vertical"],
+    orientation: str,
     diameter: float,
     face_normal: FreeCAD.Vector,
 ) -> List[FreeCAD.Vector]:

--- a/UShapeRebar.py
+++ b/UShapeRebar.py
@@ -26,7 +26,7 @@ __author__ = "Amritpal Singh"
 __url__ = "https://www.freecadweb.org"
 
 from pathlib import Path
-from typing import Tuple, Literal, List
+from typing import Tuple, List
 
 import ArchCommands
 import FreeCAD
@@ -47,13 +47,17 @@ from Rebarfunc import (
 )
 
 
+# TODO: Use(Uncomment) typing.Literal for minimum python3.8
+
+
 def getpointsOfUShapeRebar(
     FacePRM: Tuple[Tuple[float, float], Tuple[float, float]],
     r_cover: float,
     l_cover: float,
     b_cover: float,
     t_cover: float,
-    orientation: Literal["Bottom", "Top", "Left", "Right"],
+    # orientation: Literal["Bottom", "Top", "Left", "Right"],
+    orientation: str,
     diameter: float,
     face_normal: FreeCAD.Vector,
 ) -> List[FreeCAD.Vector]:


### PR DESCRIPTION
- Define and use custom Literal type if typing.Literal import fails
- Copy and modified code from python typing module to implement
  custom Literal type

Fixes #135