### PR TITLE
Added natural sorting in BOM, Rebar shape cut list and in BBS

### DIFF
--- a/BillOfMaterial/BOMfunc.py
+++ b/BillOfMaterial/BOMfunc.py
@@ -25,8 +25,8 @@ __title__ = "Bill Of Material Helper Functions"
 __author__ = "Suraj"
 __url__ = "https://www.freecadweb.org"
 
-from typing import Dict, Optional, List
-
+from typing import Dict, Optional, List, Tuple
+import re
 import Draft
 import FreeCAD
 from PySide2 import QtGui
@@ -115,6 +115,20 @@ def getReinforcementRebarObjects(objects_list=None):
     return rebars_list
 
 
+def naturalKey(item: Tuple):
+    """naturalKeys(mark):
+    item is a Tuple repesenting dictionary item
+
+    Returns list of integer or text components of key
+    """
+    key = item[0]
+
+    def atoi(keyComponent):
+        return int(keyComponent) if keyComponent.isdigit() else keyComponent
+
+    return [atoi(keyComponent) for keyComponent in re.split(r"(\d+)", key)]
+
+
 def getMarkReinforcementsDict(objects_list: List = None) -> Dict[str, List]:
     """getMarkReinforcementsDict(ObjectsList):
     objects_list is the list of ArchRebar, rebar2 and/or structural objects.
@@ -145,7 +159,7 @@ def getMarkReinforcementsDict(objects_list: List = None) -> Dict[str, List]:
             mark_reinforcements_dict[mark].append(rebar)
 
     mark_reinforcements_dict = dict(
-        sorted(mark_reinforcements_dict.items(), key=lambda item: item[0])
+        sorted(mark_reinforcements_dict.items(), key=naturalKey)
     )
 
     return mark_reinforcements_dict

--- a/RebarShapeCutList/RebarShapeCutListfunc.py
+++ b/RebarShapeCutList/RebarShapeCutListfunc.py
@@ -25,6 +25,7 @@ __title__ = "RebarShape Cut List Functions"
 __author__ = "Suraj"
 __url__ = "https://www.freecadweb.org"
 
+import re
 import math
 from typing import Union, List, Tuple, Optional
 from xml.dom import minidom
@@ -125,12 +126,26 @@ def getBaseRebarsList(
 
     rebars = sorted(
         rebars,
-        key=lambda x: str(x.MarkNumber)
-        if hasattr(x, "MarkNumber")
-        else str(x.Mark),
+        key=naturalKey,
     )
 
     return rebars
+
+
+def naturalKey(item):
+    """naturalKeys(item):
+    item is repersenting rebar item here
+
+    Returns list of integer or text components of key
+    """
+    key = (
+        str(item.MarkNumber) if hasattr(item, "MarkNumber") else str(item.Mark)
+    )
+
+    def atoi(keyComponent):
+        return int(keyComponent) if keyComponent.isdigit() else keyComponent
+
+    return [atoi(keyComponent) for keyComponent in re.split(r"(\d+)", key)]
 
 
 def getVertexesMinMaxXY(

--- a/RebarTools.py
+++ b/RebarTools.py
@@ -405,7 +405,7 @@ class ReinforcementDrawingDimensioningTool:
 
 
 def updateLocale():
-    FreeCADGui.addLanguagePath(Path(__file__).parent / "translations")
+    FreeCADGui.addLanguagePath(str(Path(__file__).parent / "translations"))
     FreeCADGui.updateLocale()
 
 


### PR DESCRIPTION
Natural sorting will sort rebar information based on type of rebar  marks eg. integer, string or combination of both,for better ordering of rebar information in Bill of Material, Rebar shape cut list and in Bar Bending Schedule. 

fixes  https://github.com/amrit3701/FreeCAD-Reinforcement/issues/96