### PR TITLE
Add translation script

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -33,12 +33,19 @@ import RebarTools
 wb_icon_path = str(
     Path(RebarTools.__file__).parent.absolute() / "icons" / "Reinforcement.svg"
 )
+FreeCADGui.addLanguagePath(
+    str(Path(RebarTools.__file__).parent.absolute() / "translations")
+)
+FreeCADGui.updateLocale()
 
 
 class ReinforcementWorkbench(FreeCADGui.Workbench):
+    from FreeCAD import Qt
+
     global wb_icon_path
-    MenuText = "Reinforcement"
-    ToolTip = "Create Building Reinforcement"
+
+    MenuText = Qt.translate("ReinforcementWorkbench", "Reinforcement")
+    ToolTip = Qt.translate("ReinforcementWorkbench", "Create Building Reinforcement")
     Icon = wb_icon_path
 
     def Initialize(self):
@@ -66,9 +73,6 @@ class ReinforcementWorkbench(FreeCADGui.Workbench):
                 / "icons"
                 / "preferences"
             )
-        )
-        FreeCADGui.addLanguagePath(
-            str(Path(RebarTools.__file__).parent.absolute() / "translations")
         )
 
     def Activated(self):

--- a/translations/Reinforcement.ts
+++ b/translations/Reinforcement.ts
@@ -2,6 +2,271 @@
 <!DOCTYPE TS>
 <TS version="2.1">
 <context>
+    <name>BOMDialog</name>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="20"/>
+        <source>BillOfMaterial</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="55"/>
+        <source>Reinforcement Group By</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="68"/>
+        <source>It specifies how reinforcement objects should be grouped</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="91"/>
+        <source>Rebar Length Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="104"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The rebar length calculations type.&lt;/p&gt;&lt;p&gt;- &amp;quot;RealLength&amp;quot;: length of rebar considering rounded edges.&lt;/p&gt;&lt;p&gt;- &amp;quot;LengthWithSharpEdges&amp;quot;: length of rebar assuming sharp edges of rebar.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="143"/>
+        <source>Column Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="159"/>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="359"/>
+        <source>Column Header</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="177"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;You can set sequence of column by dragging and dropping items in list&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="198"/>
+        <source>Font Family</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="211"/>
+        <source>The font-family of text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="234"/>
+        <source>Font Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="247"/>
+        <source>The font-size of text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="267"/>
+        <source>Column Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="280"/>
+        <source>The width of each column in bar shape cut list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="303"/>
+        <source>Row Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="316"/>
+        <source>The height of each row in bar shape cut list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="336"/>
+        <source>The data related to Rebar Shape column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="339"/>
+        <source>Rebar Shape column data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="372"/>
+        <source>The column header for rebar shape column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="375"/>
+        <source>Rebar Shape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="398"/>
+        <source>Stirrup Extended Edge Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="411"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The offset of extended end edges of stirrup, so that end edges of stirrup with 90 degree bent angle do not overlap with stirrup edges&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="414"/>
+        <source>2 mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="443"/>
+        <source>Rebars Stroke Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="456"/>
+        <source>The stroke-width of rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="459"/>
+        <source>0.35 mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="488"/>
+        <source>The color style of rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="491"/>
+        <source>Rebars Color Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="500"/>
+        <source>Select color of rebar shape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="503"/>
+        <source>shape color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="521"/>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="534"/>
+        <source>Custom color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="524"/>
+        <source>Custom Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="547"/>
+        <source>The data related to rebar shape dimensions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="550"/>
+        <source>Include Dimensions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="565"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If Checked, then rebar edge length units will be shown in dimension label&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="568"/>
+        <source>Include Units in Dimension Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="583"/>
+        <source>Dimension Font Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="596"/>
+        <source>The font-size of dimension text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="616"/>
+        <source>The units to be used for rebar edge length dimensions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="619"/>
+        <source>Rebar Edge Dimension Units</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="636"/>
+        <source>Rebar Edge Dimension Precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="649"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The number of decimals that should be shown for rebar edge length as dimension label. Set it to -1 to use user preferred unit precision from FreeCAD unit preferences&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="669"/>
+        <source>Bent Angle Dimension Exclude List</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="682"/>
+        <source>The list of bent angles to not include their dimensions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="685"/>
+        <source>45, 90, 180</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="702"/>
+        <source>Helical Rebar Dimension Label Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="715"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The format of helical rebar dimension label.&lt;/p&gt;&lt;p&gt;%L -&amp;gt; Length of helical rebar&lt;/p&gt;&lt;p&gt;%R -&amp;gt; Helix radius of helical rebar&lt;/p&gt;&lt;p&gt;%P -&amp;gt; Helix pitch of helical rebar&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="718"/>
+        <source>%L,r=%R,pitch=%P</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="745"/>
+        <source>SVG Output File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="754"/>
+        <source>The output file to write bar bending schedule svg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="757"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.ui" line="767"/>
+        <source>Choose</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BentShapeRebar</name>
     <message>
         <location filename="../BentShapeRebar.ui" line="14"/>
@@ -122,6 +387,1109 @@
     </message>
 </context>
 <context>
+    <name>BillOfMaterialDialog</name>
+    <message>
+        <location filename="../BillOfMaterial/MainBillOfMaterial.ui" line="26"/>
+        <source>BillOfMaterial</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/MainBillOfMaterial.ui" line="49"/>
+        <source>Reinforcement Group By</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/MainBillOfMaterial.ui" line="78"/>
+        <source>Rebar Length Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/MainBillOfMaterial.ui" line="120"/>
+        <source>Column Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/MainBillOfMaterial.ui" line="136"/>
+        <source>Column Header</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/MainBillOfMaterial.ui" line="160"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note:&lt;/span&gt; You can set sequence of column by dragging and dropping items in above list&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/MainBillOfMaterial.ui" line="170"/>
+        <source>Create Spreadsheet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/MainBillOfMaterial.ui" line="182"/>
+        <source>Create svg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/MainBillOfMaterial.ui" line="192"/>
+        <source>Edit SVG Configurations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/MainBillOfMaterial.ui" line="216"/>
+        <source>SVG Output File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/MainBillOfMaterial.ui" line="232"/>
+        <source>Choose</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/MainBillOfMaterial.ui" line="246"/>
+        <source>Save Preferences</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Columns</name>
+    <message>
+        <location filename="../FootingReinforcement/Columns.ui" line="20"/>
+        <source>Dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/Columns.ui" line="128"/>
+        <source>Fill values for Footing Columns </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/Columns.ui" line="135"/>
+        <source>Front Spacing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/Columns.ui" line="142"/>
+        <location filename="../FootingReinforcement/Columns.ui" line="159"/>
+        <location filename="../FootingReinforcement/Columns.ui" line="176"/>
+        <location filename="../FootingReinforcement/Columns.ui" line="193"/>
+        <source>20 mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/Columns.ui" line="152"/>
+        <source>Left Spacing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/Columns.ui" line="169"/>
+        <source>Right Spacing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/Columns.ui" line="186"/>
+        <source>Rear Spacing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/Columns.ui" line="203"/>
+        <source>Column Length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/Columns.ui" line="210"/>
+        <location filename="../FootingReinforcement/Columns.ui" line="227"/>
+        <source>200 mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/Columns.ui" line="220"/>
+        <source>Column Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/Columns.ui" line="243"/>
+        <source>Fill values for X Direction Columns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/Columns.ui" line="255"/>
+        <location filename="../FootingReinforcement/Columns.ui" line="274"/>
+        <location filename="../FootingReinforcement/Columns.ui" line="321"/>
+        <location filename="../FootingReinforcement/Columns.ui" line="344"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/Columns.ui" line="265"/>
+        <location filename="../FootingReinforcement/Columns.ui" line="288"/>
+        <location filename="../FootingReinforcement/Columns.ui" line="334"/>
+        <location filename="../FootingReinforcement/Columns.ui" line="358"/>
+        <source>Spacing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/Columns.ui" line="298"/>
+        <location filename="../FootingReinforcement/Columns.ui" line="368"/>
+        <source>50 mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/Columns.ui" line="314"/>
+        <source>Fill values for Y Direction Columns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/Columns.ui" line="381"/>
+        <source>Add Secondary Rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CrossRebars</name>
+    <message>
+        <location filename="../FootingReinforcement/CrossRebars.ui" line="14"/>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="14"/>
+        <source>Dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/CrossRebars.ui" line="80"/>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="347"/>
+        <source>Rebar Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/CrossRebars.ui" line="97"/>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="84"/>
+        <source>Front Cover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/CrossRebars.ui" line="104"/>
+        <location filename="../FootingReinforcement/CrossRebars.ui" line="121"/>
+        <location filename="../FootingReinforcement/CrossRebars.ui" line="138"/>
+        <location filename="../FootingReinforcement/CrossRebars.ui" line="155"/>
+        <location filename="../FootingReinforcement/CrossRebars.ui" line="172"/>
+        <location filename="../FootingReinforcement/CrossRebars.ui" line="189"/>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="91"/>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="108"/>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="125"/>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="142"/>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="159"/>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="176"/>
+        <source>20 mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/CrossRebars.ui" line="114"/>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="101"/>
+        <source>Left Cover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/CrossRebars.ui" line="131"/>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="118"/>
+        <source>Right Cover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/CrossRebars.ui" line="148"/>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="135"/>
+        <source>Bottom Cover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/CrossRebars.ui" line="165"/>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="152"/>
+        <source>Top Cover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/CrossRebars.ui" line="182"/>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="169"/>
+        <source>Rear Cover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/CrossRebars.ui" line="211"/>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="198"/>
+        <source>Hook Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/CrossRebars.ui" line="228"/>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="249"/>
+        <source>Rounding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/CrossRebars.ui" line="242"/>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="263"/>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="377"/>
+        <source>Diameter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/CrossRebars.ui" line="249"/>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="270"/>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="384"/>
+        <source>8 mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/CrossRebars.ui" line="261"/>
+        <location filename="../FootingReinforcement/CrossRebars.ui" line="286"/>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="282"/>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="307"/>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="394"/>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="417"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/CrossRebars.ui" line="274"/>
+        <location filename="../FootingReinforcement/CrossRebars.ui" line="300"/>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="295"/>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="321"/>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="407"/>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="434"/>
+        <source>Spacing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/CrossRebars.ui" line="310"/>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="222"/>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="331"/>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="444"/>
+        <source>50 mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="215"/>
+        <source>Anchor Length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="232"/>
+        <source>Bent Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="354"/>
+        <source>Add Distribution Rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/CrossRebars.ui" line="370"/>
+        <source>Fill values for Distribution Rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Dialog</name>
+    <message>
+        <location filename="../BillOfMaterial/EditSVGConfiguration.ui" line="14"/>
+        <source>Dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/EditSVGConfiguration.ui" line="20"/>
+        <source>Font Family</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/EditSVGConfiguration.ui" line="39"/>
+        <source>Font Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/EditSVGConfiguration.ui" line="53"/>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="219"/>
+        <source>Column Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/EditSVGConfiguration.ui" line="70"/>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="183"/>
+        <source>Row Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/EditSVGConfiguration.ui" line="87"/>
+        <source>BOM Left Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/EditSVGConfiguration.ui" line="104"/>
+        <source>BOM Top Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/EditSVGConfiguration.ui" line="121"/>
+        <source>BOM Min Right Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/EditSVGConfiguration.ui" line="138"/>
+        <source>BOM Min Bottom Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/EditSVGConfiguration.ui" line="155"/>
+        <source>BOM Max Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/EditSVGConfiguration.ui" line="172"/>
+        <source>BOM Max Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/EditSVGConfiguration.ui" line="189"/>
+        <source>Template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/EditSVGConfiguration.ui" line="211"/>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="618"/>
+        <source>Choose</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="14"/>
+        <source>RebarShapeCutList</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="34"/>
+        <source>Stirrup Extended Edge Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="47"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The offset of extended end edges of stirrup, so that end edges of stirrup with 90 degree bent angle do not overlap with stirrup edges&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="50"/>
+        <source>2 mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="79"/>
+        <source>Rebars Stroke Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="92"/>
+        <source>The stroke-width of rebars in rebar shape cut list svg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="95"/>
+        <source>0.35 mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="124"/>
+        <source>The color style of rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="127"/>
+        <source>Rebars Color Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="134"/>
+        <source>Select color of rebar shape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="137"/>
+        <source>shape color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="153"/>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="166"/>
+        <source>Custom color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="196"/>
+        <source>The height of each row of rebar shape in rebar shape cut list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="232"/>
+        <source>The width of rebar shape cut list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="255"/>
+        <source>Column Count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="273"/>
+        <source>The number of columns in rebar shape cut list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="283"/>
+        <source>Set column_count &lt;= row_count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="286"/>
+        <source>Row Count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="308"/>
+        <source>Side Padding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="321"/>
+        <source>The padding on each side of rebar shape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="338"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If Checked, then max length edge of rebar shape will be rotated to make it horizontal&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="341"/>
+        <source>Horizontal Rebar Shape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="351"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If Checked, then rebar.Mark will be included for each rebar shape in rebar shape cut list svg&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="354"/>
+        <source>Include Mark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="366"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If Checked, then each rebar edge dimensions and bent angle dimensions will be included in rebar shape cut list&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="369"/>
+        <source>Include Dimensions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="378"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If Checked, then rebar edge length units will be shown in dimension label&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="381"/>
+        <source>Include Units in Dimension Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="396"/>
+        <source>The units to be used for rebar edge length dimensions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="399"/>
+        <source>Rebar Edge Dimension Units</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="416"/>
+        <source>Rebar Edge Dimension Precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="429"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The number of decimals that should be shown for rebar edge length as dimension label. Set it to -1 to use user preferred unit precision from FreeCAD unit preferences&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="449"/>
+        <source>Dimension Font Family</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="462"/>
+        <source>The font-family of dimension text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="485"/>
+        <source>Dimension Font Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="498"/>
+        <source>The font-size of dimension text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="518"/>
+        <source>Bent Angle Dimension Exclude List</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="525"/>
+        <source>The list of bent angles to not include their dimensions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="528"/>
+        <source>45, 90, 180</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="545"/>
+        <source>Helical Rebar Dimension Label Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="558"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The format of helical rebar dimension label.&lt;/p&gt;&lt;p&gt;%L -&amp;gt; Length of helical rebar&lt;/p&gt;&lt;p&gt;%R -&amp;gt; Helix radius of helical rebar&lt;/p&gt;&lt;p&gt;%P -&amp;gt; Helix pitch of helical rebar&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="561"/>
+        <source>%L,r=%R,pitch=%P</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="599"/>
+        <source>SVG Output File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.ui" line="608"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Form</name>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="14"/>
+        <source>BillOfMaterial</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="31"/>
+        <source>BOM Preferences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="48"/>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="71"/>
+        <source>Reinforcement Group By</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="85"/>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="255"/>
+        <source>Mark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="90"/>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="206"/>
+        <source>Host</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="114"/>
+        <source>RebarLengthType</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="128"/>
+        <source>RealLength</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="133"/>
+        <source>LengthWithSharpEdges</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="143"/>
+        <source>Column Headers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="163"/>
+        <source>Column Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="179"/>
+        <source>Column Header</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="189"/>
+        <source>Sequence</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="229"/>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="278"/>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="327"/>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="376"/>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="425"/>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="474"/>
+        <source>Set sequence to 0 to hide column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="304"/>
+        <source>RebarsCount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="353"/>
+        <location filename="../ColumnReinforcement/CircularColumn.ui" line="85"/>
+        <location filename="../ColumnReinforcement/CircularColumn.ui" line="112"/>
+        <location filename="../ColumnReinforcement/MainRebars.ui" line="69"/>
+        <location filename="../ColumnReinforcement/Ties.ui" line="154"/>
+        <location filename="../FootingReinforcement/MainRebars.ui" line="178"/>
+        <location filename="../FootingReinforcement/Ties.ui" line="97"/>
+        <source>Diameter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="402"/>
+        <source>RebarLength</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="451"/>
+        <source>RebarsTotalLength</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="495"/>
+        <source>Column Units</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="509"/>
+        <source>Diameter unit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="536"/>
+        <source>RebarLength unit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="563"/>
+        <source>RebarsTotalLength unit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="585"/>
+        <source>Rebar Diameter Weight Map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="620"/>
+        <source>6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="627"/>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="666"/>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="705"/>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="744"/>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="783"/>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="822"/>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="861"/>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="900"/>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="939"/>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="978"/>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="1017"/>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="1056"/>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="1095"/>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="1134"/>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="1173"/>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="1212"/>
+        <source> kg/mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="659"/>
+        <source>8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="698"/>
+        <source>10</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="737"/>
+        <source>12</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="776"/>
+        <source>14</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="815"/>
+        <source>16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="854"/>
+        <source>18</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="893"/>
+        <source>20</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="932"/>
+        <source>22</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="971"/>
+        <source>25</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="1010"/>
+        <source>28</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="1049"/>
+        <source>32</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="1088"/>
+        <source>36</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="1127"/>
+        <source>40</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="1166"/>
+        <source>45</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="1205"/>
+        <source>50</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="1238"/>
+        <source>SVG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="1244"/>
+        <source>Font Family</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="1270"/>
+        <source>Font Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="1287"/>
+        <source>Column Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="1307"/>
+        <source>Row Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="1327"/>
+        <source>BOM Left Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="1347"/>
+        <source>BOM Top Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="1367"/>
+        <source>BOM Min Right Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="1387"/>
+        <source>BOM Min Bottom Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="1407"/>
+        <source>BOM Max Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="1427"/>
+        <source>BOM Max Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="1447"/>
+        <source>Template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BOMPreferences.ui" line="1464"/>
+        <source>Font Filename</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/CircularColumn.ui" line="14"/>
+        <location filename="../ColumnReinforcement/MainRebars.ui" line="14"/>
+        <location filename="../ColumnReinforcement/Ties.ui" line="14"/>
+        <location filename="../FootingReinforcement/MainRebars.ui" line="14"/>
+        <location filename="../FootingReinforcement/Ties.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/CircularColumn.ui" line="20"/>
+        <source>50 mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/CircularColumn.ui" line="36"/>
+        <source> °</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/CircularColumn.ui" line="52"/>
+        <location filename="../ColumnReinforcement/CircularColumn.ui" line="199"/>
+        <location filename="../ColumnReinforcement/CircularColumn.ui" line="263"/>
+        <source>20 mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/CircularColumn.ui" line="65"/>
+        <location filename="../ColumnReinforcement/CircularColumn.ui" line="185"/>
+        <location filename="../ColumnReinforcement/MainRebars.ui" line="141"/>
+        <location filename="../FootingReinforcement/MainRebars.ui" line="129"/>
+        <source>Top Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/CircularColumn.ui" line="72"/>
+        <location filename="../ColumnReinforcement/CircularColumn.ui" line="119"/>
+        <location filename="../ColumnReinforcement/MainRebars.ui" line="47"/>
+        <location filename="../FootingReinforcement/MainRebars.ui" line="103"/>
+        <source>40 mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/CircularColumn.ui" line="98"/>
+        <source>Helical Rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/CircularColumn.ui" line="105"/>
+        <source>Pitch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/CircularColumn.ui" line="138"/>
+        <source>Main Rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/CircularColumn.ui" line="145"/>
+        <source>8 mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/CircularColumn.ui" line="158"/>
+        <source>16 mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/CircularColumn.ui" line="171"/>
+        <location filename="../ColumnReinforcement/CircularColumn.ui" line="239"/>
+        <location filename="../ColumnReinforcement/MainRebars.ui" line="37"/>
+        <source>Bottom Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/CircularColumn.ui" line="178"/>
+        <source>Side Cover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/CircularColumn.ui" line="192"/>
+        <location filename="../ColumnReinforcement/CircularColumn.ui" line="230"/>
+        <source>Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/CircularColumn.ui" line="220"/>
+        <location filename="../ColumnReinforcement/CircularColumn.ui" line="246"/>
+        <location filename="../ColumnReinforcement/Ties.ui" line="200"/>
+        <location filename="../ColumnReinforcement/Ties.ui" line="219"/>
+        <location filename="../FootingReinforcement/Ties.ui" line="143"/>
+        <location filename="../FootingReinforcement/Ties.ui" line="162"/>
+        <source>Number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/MainRebars.ui" line="20"/>
+        <location filename="../ColumnReinforcement/MainRebars.ui" line="118"/>
+        <location filename="../ColumnReinforcement/MainRebars.ui" line="155"/>
+        <location filename="../ColumnReinforcement/Ties.ui" line="67"/>
+        <location filename="../ColumnReinforcement/Ties.ui" line="87"/>
+        <location filename="../ColumnReinforcement/Ties.ui" line="107"/>
+        <location filename="../ColumnReinforcement/Ties.ui" line="127"/>
+        <location filename="../ColumnReinforcement/Ties.ui" line="144"/>
+        <location filename="../ColumnReinforcement/Ties.ui" line="246"/>
+        <location filename="../FootingReinforcement/MainRebars.ui" line="70"/>
+        <location filename="../FootingReinforcement/MainRebars.ui" line="119"/>
+        <location filename="../FootingReinforcement/Ties.ui" line="67"/>
+        <location filename="../FootingReinforcement/Ties.ui" line="87"/>
+        <location filename="../FootingReinforcement/Ties.ui" line="189"/>
+        <source>0 </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/MainRebars.ui" line="88"/>
+        <location filename="../FootingReinforcement/MainRebars.ui" line="49"/>
+        <source>Hook Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/MainRebars.ui" line="101"/>
+        <location filename="../FootingReinforcement/MainRebars.ui" line="142"/>
+        <source>Rebar Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/MainRebars.ui" line="134"/>
+        <location filename="../FootingReinforcement/MainRebars.ui" line="86"/>
+        <source>Main Rebars:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/MainRebars.ui" line="148"/>
+        <location filename="../FootingReinforcement/MainRebars.ui" line="93"/>
+        <source>Hook Extend Along</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/MainRebars.ui" line="165"/>
+        <location filename="../FootingReinforcement/MainRebars.ui" line="185"/>
+        <source>Rounding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/MainRebars.ui" line="179"/>
+        <location filename="../FootingReinforcement/MainRebars.ui" line="63"/>
+        <source>Hook Extension</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/Ties.ui" line="53"/>
+        <location filename="../FootingReinforcement/Ties.ui" line="53"/>
+        <source>Ties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/Ties.ui" line="60"/>
+        <source>Left Cover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/Ties.ui" line="77"/>
+        <source>Right Cover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/Ties.ui" line="97"/>
+        <location filename="../FootingReinforcement/Ties.ui" line="60"/>
+        <source>Top Cover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/Ties.ui" line="117"/>
+        <location filename="../FootingReinforcement/Ties.ui" line="77"/>
+        <source>Bottom Cover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/Ties.ui" line="137"/>
+        <source>Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/Ties.ui" line="168"/>
+        <location filename="../FootingReinforcement/Ties.ui" line="111"/>
+        <source>Bent Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/Ties.ui" line="178"/>
+        <location filename="../FootingReinforcement/Ties.ui" line="121"/>
+        <source>Extension Factor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/Ties.ui" line="210"/>
+        <location filename="../ColumnReinforcement/Ties.ui" line="236"/>
+        <location filename="../FootingReinforcement/Ties.ui" line="153"/>
+        <location filename="../FootingReinforcement/Ties.ui" line="179"/>
+        <source>Spacing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/Ties.ui" line="267"/>
+        <source>Custom Spacing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/Ties.ui" line="283"/>
+        <source>Remove Spacing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/Ties.ui" line="292"/>
+        <source>Set all covers equal</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LShapeRebar</name>
     <message>
         <location filename="../LShapeRebar.ui" line="14"/>
@@ -231,6 +1599,317 @@
     </message>
 </context>
 <context>
+    <name>MainColumnReinforcementDialog</name>
+    <message>
+        <location filename="../ColumnReinforcement/MainColumnReinforcement.ui" line="26"/>
+        <source>Dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/MainColumnReinforcement.ui" line="63"/>
+        <source>Rectangular Column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/MainColumnReinforcement.ui" line="92"/>
+        <source>Circular Column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/MainColumnReinforcement.ui" line="125"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/MainColumnReinforcement.ui" line="132"/>
+        <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/MainColumnReinforcement.ui" line="171"/>
+        <source>Ties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/MainColumnReinforcement.ui" line="176"/>
+        <source>Main Rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/MainColumnReinforcement.ui" line="181"/>
+        <source>XDir Secondary Rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/MainColumnReinforcement.ui" line="186"/>
+        <source>YDir Secondary Rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/MainColumnReinforcement.ui" line="250"/>
+        <source>image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/MainColumnReinforcement.ui" line="285"/>
+        <source>Adjust by dragging items</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/MainColumnReinforcement.ui" line="288"/>
+        <source>Ties Sequence</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/MainColumnReinforcement.ui" line="314"/>
+        <source>Tie1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/MainColumnReinforcement.ui" line="319"/>
+        <source>Tie2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MainFootingReinforcementDialog</name>
+    <message>
+        <location filename="../FootingReinforcement/MainFootingReinforcement.ui" line="26"/>
+        <source>Dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/MainFootingReinforcement.ui" line="34"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/MainFootingReinforcement.ui" line="41"/>
+        <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/MainFootingReinforcement.ui" line="96"/>
+        <source>Parallel Rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/MainFootingReinforcement.ui" line="101"/>
+        <source>Cross Rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/MainFootingReinforcement.ui" line="106"/>
+        <source>Columns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/MainFootingReinforcement.ui" line="111"/>
+        <source>Ties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/MainFootingReinforcement.ui" line="116"/>
+        <source>Main Rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/MainFootingReinforcement.ui" line="121"/>
+        <source>XDir Secondary Rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/MainFootingReinforcement.ui" line="126"/>
+        <source>YDir Secondary Rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/MainFootingReinforcement.ui" line="210"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#fc0107;&quot;&gt;This feature is currently in development mode&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MainSlabReinforcementDialog</name>
+    <message>
+        <location filename="../SlabReinforcement/MainSlabReinforcement.ui" line="26"/>
+        <source>Dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/MainSlabReinforcement.ui" line="78"/>
+        <source>Parallel Rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/MainSlabReinforcement.ui" line="83"/>
+        <source>Cross Rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/MainSlabReinforcement.ui" line="163"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/MainSlabReinforcement.ui" line="170"/>
+        <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/MainSlabReinforcement.ui" line="188"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#fc0107;&quot;&gt;This feature is currently in development mode&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ParallelRebars</name>
+    <message>
+        <location filename="../FootingReinforcement/ParallelRebars.ui" line="20"/>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="20"/>
+        <source>Dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/ParallelRebars.ui" line="125"/>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="125"/>
+        <source>Mesh Cover Along</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/ParallelRebars.ui" line="141"/>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="141"/>
+        <source>Rebar Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/ParallelRebars.ui" line="158"/>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="158"/>
+        <source>Front Cover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/ParallelRebars.ui" line="165"/>
+        <location filename="../FootingReinforcement/ParallelRebars.ui" line="182"/>
+        <location filename="../FootingReinforcement/ParallelRebars.ui" line="199"/>
+        <location filename="../FootingReinforcement/ParallelRebars.ui" line="216"/>
+        <location filename="../FootingReinforcement/ParallelRebars.ui" line="233"/>
+        <location filename="../FootingReinforcement/ParallelRebars.ui" line="250"/>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="165"/>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="182"/>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="199"/>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="216"/>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="233"/>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="250"/>
+        <source>20 mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/ParallelRebars.ui" line="175"/>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="175"/>
+        <source>Left Cover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/ParallelRebars.ui" line="192"/>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="192"/>
+        <source>Right Cover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/ParallelRebars.ui" line="209"/>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="209"/>
+        <source>Bottom Cover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/ParallelRebars.ui" line="226"/>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="226"/>
+        <source>Top Cover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/ParallelRebars.ui" line="243"/>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="243"/>
+        <source>Rear Cover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/ParallelRebars.ui" line="272"/>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="272"/>
+        <source>Hook Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/ParallelRebars.ui" line="286"/>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="320"/>
+        <source>Rounding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/ParallelRebars.ui" line="300"/>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="334"/>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="432"/>
+        <source>Diameter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/ParallelRebars.ui" line="307"/>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="341"/>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="439"/>
+        <source>8 mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/ParallelRebars.ui" line="322"/>
+        <location filename="../FootingReinforcement/ParallelRebars.ui" line="341"/>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="356"/>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="375"/>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="449"/>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="472"/>
+        <source>Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/ParallelRebars.ui" line="332"/>
+        <location filename="../FootingReinforcement/ParallelRebars.ui" line="355"/>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="366"/>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="389"/>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="462"/>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="486"/>
+        <source>Spacing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/ParallelRebars.ui" line="365"/>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="293"/>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="399"/>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="496"/>
+        <source>50 mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="286"/>
+        <source>Anchor Length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="303"/>
+        <source>Bent Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="409"/>
+        <source>Add Distribution Rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/ParallelRebars.ui" line="425"/>
+        <source>Fill values for Distribution Rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>RebarDistribution</name>
     <message>
         <location filename="../RebarDistribution.ui" line="14"/>
@@ -281,6 +1960,986 @@
     <message>
         <location filename="../RebarDistribution.ui" line="153"/>
         <source>Segment 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>RebarNumberDiameterDialog</name>
+    <message>
+        <location filename="../ColumnReinforcement/RebarNumberDiameter.ui" line="14"/>
+        <source>Dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/RebarNumberDiameter.ui" line="44"/>
+        <source>Number of rebars (n)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/RebarNumberDiameter.ui" line="57"/>
+        <source>Diameter (d)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/RebarNumberDiameter.ui" line="68"/>
+        <source>Number#Diameter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/RebarNumberDiameter.ui" line="81"/>
+        <source>2#20mm+1#16mm+2#20mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/RebarNumberDiameter.ui" line="101"/>
+        <source>Set 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/RebarNumberDiameter.ui" line="127"/>
+        <source>16 mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/RebarNumberDiameter.ui" line="150"/>
+        <source>Set 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/RebarNumberDiameter.ui" line="176"/>
+        <location filename="../ColumnReinforcement/RebarNumberDiameter.ui" line="257"/>
+        <source>20 mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/RebarNumberDiameter.ui" line="203"/>
+        <source>Rebars Number Diameter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/RebarNumberDiameter.ui" line="231"/>
+        <source>Set 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ReinforcementDrawingAndDimensioning_Dimensions1</name>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions1.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions1.ui" line="25"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The data related to Dimension Label&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions1.ui" line="28"/>
+        <source>Dimension Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions1.ui" line="70"/>
+        <source>Dimension Label Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions1.ui" line="86"/>
+        <source>Dimension Font Family</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions1.ui" line="93"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The font family of dimension label&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions1.ui" line="112"/>
+        <source>Dimension Font Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions1.ui" line="119"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The font size of the dimension label&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions1.ui" line="135"/>
+        <source>Dimension Text Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions1.ui" line="142"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The color of the dimension label&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions1.ui" line="161"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The data related to Dimension Line&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions1.ui" line="164"/>
+        <source>Dimension Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions1.ui" line="206"/>
+        <source>Dimension Stroke Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions1.ui" line="213"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The stroke-width of dimension line&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions1.ui" line="216"/>
+        <source>0.35 mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions1.ui" line="235"/>
+        <source>Dimension Line Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions1.ui" line="242"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The stroke style of dimension line&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions1.ui" line="252"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions1.ui" line="257"/>
+        <source>Dash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions1.ui" line="262"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions1.ui" line="328"/>
+        <source>Dot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions1.ui" line="267"/>
+        <source>DashDot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions1.ui" line="272"/>
+        <source>DashDotDot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions1.ui" line="286"/>
+        <source>Dimension Line Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions1.ui" line="293"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The color of the dimension line&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions1.ui" line="306"/>
+        <source>Dimension Line Mid Point Symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions1.ui" line="313"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The dimension line midpoints symbol&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions1.ui" line="323"/>
+        <source>Thick</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions1.ui" line="333"/>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ReinforcementDrawingAndDimensioning_Dimensions2</name>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="25"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The data related to Single Rebar Dimension&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="28"/>
+        <source>Single Rebar Dimension</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="76"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="294"/>
+        <source>Dimension Line Start Symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="83"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The dimension line start symbol, in case of single rebar is visible&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="93"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="145"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="311"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="363"/>
+        <source>FilledArrow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="98"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="150"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="316"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="368"/>
+        <source>Thick</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="103"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="155"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="321"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="373"/>
+        <source>Dot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="108"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="160"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="326"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="378"/>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="128"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="346"/>
+        <source>Dimension Line End Symbol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="135"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The dimension line end symbol, in case of single rebar is visible&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="180"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="398"/>
+        <source>Text Position Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="187"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The dimension label position type, in case of single rebar is visible&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="197"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="415"/>
+        <source>StartOfLine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="202"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="420"/>
+        <source>MidOfLine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="207"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="425"/>
+        <source>EndOfLine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="221"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If Checked, then dimension lines are to be outside of reinforcement drawing, in case of single rebar is visible&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="224"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="442"/>
+        <source>Outer Dimension</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="243"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The data related to Multi Rebar Dimension&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="246"/>
+        <source>Multi Rebar Dimension</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="301"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The dimension line start symbol, in case of multiple rebars are visible&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="353"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The dimension line end symbol, in case of multiple rebars are visible&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="405"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The dimension label position type, in case of multiple rebars are visible&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui" line="439"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If Checked, then dimension lines are to be outside of reinforcement drawing, in case of multiple rebars are visible&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ReinforcementDrawingAndDimensioning_Dimensions3</name>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions3.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions3.ui" line="25"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions3.ui" line="240"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The data related to Dimension Offset&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions3.ui" line="28"/>
+        <source>Dimension Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions3.ui" line="76"/>
+        <source>Left Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions3.ui" line="89"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The left offset of the dimension from drawing&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions3.ui" line="92"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions3.ui" line="133"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions3.ui" line="174"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions3.ui" line="215"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions3.ui" line="307"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions3.ui" line="348"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions3.ui" line="389"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions3.ui" line="430"/>
+        <source>0.35 mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions3.ui" line="117"/>
+        <source>Right Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions3.ui" line="130"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The right offset of the dimension from drawing&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions3.ui" line="158"/>
+        <source>Top Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions3.ui" line="171"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The top offset of the dimension from drawing&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions3.ui" line="199"/>
+        <source>Bottom Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions3.ui" line="212"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The bottom offset of the dimension from drawing&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions3.ui" line="243"/>
+        <source>Dimension Offset Increment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions3.ui" line="291"/>
+        <source>Left Offset Increment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions3.ui" line="304"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The increment in the left offset to move each new dimension label away from drawing&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions3.ui" line="332"/>
+        <source>Right Offset Increment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions3.ui" line="345"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The increment in the right offset to move each new dimension label away from drawing&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions3.ui" line="373"/>
+        <source>Top Offset Increment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions3.ui" line="386"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The increment in the top offset to move each new dimension label away from drawing&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions3.ui" line="414"/>
+        <source>Bottom Offset Increment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions3.ui" line="427"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The increment in the bottom offset to move each new dimension label away from drawing&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ReinforcementDrawingAndDimensioning_Drawing</name>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="14"/>
+        <source>ReinforcementDrawingAndDimensioning_Drawing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="20"/>
+        <source>Drawing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="56"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The maximum width of drawing on &lt;span style=&quot; font-family:&apos;monospace&apos;;&quot;&gt;template&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="59"/>
+        <source>297 mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="72"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The maximum height of drawing on &lt;span style=&quot; font-family:&apos;monospace&apos;;&quot;&gt;template&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="75"/>
+        <source>210 mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="88"/>
+        <source>Drawing Min Bottom Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="110"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If Checked, then Right view is generated&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="113"/>
+        <source>Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="126"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If Checked, then Top view is generated&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="129"/>
+        <source>Top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="142"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If Checked, then Rear view is generated&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="145"/>
+        <source>Rear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="158"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If Checked, then Front view is generated&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="161"/>
+        <source>Front</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="177"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If Checked, then Bottom view is generated&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="180"/>
+        <source>Bottom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="193"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If Checked, then Left view is generated&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="196"/>
+        <source>Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="206"/>
+        <source>Drawing Top Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="213"/>
+        <source>Drawing Min Right Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="220"/>
+        <source>Drawing Left Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="227"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Dimensioning is performed&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="230"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="243"/>
+        <source>Drawing Max Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="253"/>
+        <source>Views</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="263"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The minimum bottom offset of the drawing view on &lt;span style=&quot; font-family:&apos;monospace&apos;;&quot;&gt;template&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="266"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="282"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="342"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="368"/>
+        <source>0.35 mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="279"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The top offset of the drawing view on t&lt;span style=&quot; font-family:&apos;monospace&apos;;&quot;&gt;emplate&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="295"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Dimensioning is not performed&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="298"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="308"/>
+        <source>Template File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="317"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The template file to be used for the reinforcement drawing page&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="320"/>
+        <source>required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="330"/>
+        <source>Choose</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="339"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The left offset of the drawing view on t&lt;span style=&quot; font-family:&apos;monospace&apos;;&quot;&gt;emplate&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="358"/>
+        <source>Dimensioning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="365"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The minimum right offset of the drawing view on &lt;span style=&quot; font-family:&apos;monospace&apos;;&quot;&gt;template&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui" line="381"/>
+        <source>Drawing Max Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ReinforcementDrawingAndDimensioning_Main</name>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Main.ui" line="20"/>
+        <source>Dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Main.ui" line="28"/>
+        <source>Back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Main.ui" line="35"/>
+        <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Main.ui" line="81"/>
+        <source>Shapes - Rebars &amp; Structure</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Main.ui" line="86"/>
+        <source>Drawing - Views &amp; Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Main.ui" line="91"/>
+        <source>Dimensions - Labels &amp; Lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Main.ui" line="96"/>
+        <source>Dimensions - Single &amp; Multi Rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Main.ui" line="101"/>
+        <source>Dimensions - Offsets &amp; Increments</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ReinforcementDrawingAndDimensioning_Shapes</name>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Shapes.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Shapes.ui" line="25"/>
+        <source>The data related to Rebar Shape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Shapes.ui" line="28"/>
+        <source>Rebar Shape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Shapes.ui" line="76"/>
+        <source>Rebars Stroke Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Shapes.ui" line="89"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The stroke-width of rebars&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Shapes.ui" line="92"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Shapes.ui" line="259"/>
+        <source>0.35 mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Shapes.ui" line="117"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Shapes.ui" line="284"/>
+        <source>The color style of rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Shapes.ui" line="120"/>
+        <source>Rebars Color Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Shapes.ui" line="129"/>
+        <source>Select color of rebar shape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Shapes.ui" line="132"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Shapes.ui" line="299"/>
+        <source>shape color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Shapes.ui" line="153"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Shapes.ui" line="169"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Shapes.ui" line="330"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Shapes.ui" line="346"/>
+        <source>Custom color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Shapes.ui" line="156"/>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Shapes.ui" line="333"/>
+        <source>custom color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Shapes.ui" line="192"/>
+        <source>The data related to Structure Shape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Shapes.ui" line="195"/>
+        <source>Structure Shape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Shapes.ui" line="243"/>
+        <source>Structure Stroke Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Shapes.ui" line="256"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The stroke-width of structure&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Shapes.ui" line="287"/>
+        <source>Structure Color Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Shapes.ui" line="296"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select color of structure shape&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingDimensioning_Shapes.ui" line="312"/>
+        <source>no color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SecXDirRebarsWidget</name>
+    <message>
+        <location filename="../ColumnReinforcement/SecXDirRebars.ui" line="17"/>
+        <location filename="../FootingReinforcement/SecXDirRebars.ui" line="17"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/SecXDirRebars.ui" line="30"/>
+        <location filename="../FootingReinforcement/SecXDirRebars.ui" line="103"/>
+        <source>Hook Extension</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/SecXDirRebars.ui" line="47"/>
+        <location filename="../FootingReinforcement/SecXDirRebars.ui" line="23"/>
+        <source>Rounding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/SecXDirRebars.ui" line="57"/>
+        <location filename="../FootingReinforcement/SecXDirRebars.ui" line="156"/>
+        <source>40 mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/SecXDirRebars.ui" line="73"/>
+        <source>Bottom Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/SecXDirRebars.ui" line="92"/>
+        <location filename="../FootingReinforcement/SecXDirRebars.ui" line="129"/>
+        <source>2#20mm+1#16mm+2#20mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/SecXDirRebars.ui" line="99"/>
+        <location filename="../FootingReinforcement/SecXDirRebars.ui" line="86"/>
+        <source>Rebar Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/SecXDirRebars.ui" line="106"/>
+        <location filename="../FootingReinforcement/SecXDirRebars.ui" line="79"/>
+        <source>Number#Diameter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/SecXDirRebars.ui" line="113"/>
+        <location filename="../FootingReinforcement/SecXDirRebars.ui" line="110"/>
+        <source>Top Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/SecXDirRebars.ui" line="132"/>
+        <location filename="../FootingReinforcement/SecXDirRebars.ui" line="62"/>
+        <source>Hook Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/SecXDirRebars.ui" line="139"/>
+        <location filename="../FootingReinforcement/SecXDirRebars.ui" line="30"/>
+        <source>Edit Number and Diameter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/SecXDirRebars.ui" line="146"/>
+        <location filename="../ColumnReinforcement/SecXDirRebars.ui" line="169"/>
+        <location filename="../FootingReinforcement/SecXDirRebars.ui" line="136"/>
+        <source>0 </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/SecXDirRebars.ui" line="162"/>
+        <source>Secondary Rebars Along x-direction:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/SecXDirRebars.ui" line="178"/>
+        <source>Secondary Rebars Along x-direction in a column:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SecYDirRebarsWidget</name>
+    <message>
+        <location filename="../ColumnReinforcement/SecYDirRebars.ui" line="17"/>
+        <location filename="../FootingReinforcement/SecYDirRebars.ui" line="17"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/SecYDirRebars.ui" line="23"/>
+        <location filename="../FootingReinforcement/SecYDirRebars.ui" line="56"/>
+        <source>Edit Number and Diameter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/SecYDirRebars.ui" line="42"/>
+        <location filename="../FootingReinforcement/SecYDirRebars.ui" line="35"/>
+        <source>1#20mm+1#16mm+1#20mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/SecYDirRebars.ui" line="55"/>
+        <source>Secondary Rebars Along y-direction:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/SecYDirRebars.ui" line="65"/>
+        <location filename="../FootingReinforcement/SecYDirRebars.ui" line="66"/>
+        <source>40 mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/SecYDirRebars.ui" line="81"/>
+        <location filename="../FootingReinforcement/SecYDirRebars.ui" line="112"/>
+        <source>Hook Extension</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/SecYDirRebars.ui" line="88"/>
+        <location filename="../FootingReinforcement/SecYDirRebars.ui" line="42"/>
+        <source>Top Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/SecYDirRebars.ui" line="95"/>
+        <location filename="../FootingReinforcement/SecYDirRebars.ui" line="161"/>
+        <source>Rebar Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/SecYDirRebars.ui" line="102"/>
+        <source>Bottom Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/SecYDirRebars.ui" line="109"/>
+        <location filename="../ColumnReinforcement/SecYDirRebars.ui" line="126"/>
+        <location filename="../FootingReinforcement/SecYDirRebars.ui" line="168"/>
+        <source>0 </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/SecYDirRebars.ui" line="119"/>
+        <location filename="../FootingReinforcement/SecYDirRebars.ui" line="105"/>
+        <source>Rounding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/SecYDirRebars.ui" line="153"/>
+        <location filename="../FootingReinforcement/SecYDirRebars.ui" line="178"/>
+        <source>Number#Diameter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/SecYDirRebars.ui" line="172"/>
+        <location filename="../FootingReinforcement/SecYDirRebars.ui" line="131"/>
+        <source>Hook Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/SecYDirRebars.ui" line="144"/>
+        <source>Secondary Rebars Along y-direction in a column:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -573,6 +3232,86 @@
 <context>
     <name>App::Property</name>
     <message>
+        <location filename="../BillOfMaterial/BillOfMaterialContent.py" line="59"/>
+        <source>The font family of Bill of Material content</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BillOfMaterialContent.py" line="71"/>
+        <source>The font filename for font of Bill of Material content and is required for working in pure console mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BillOfMaterialContent.py" line="85"/>
+        <source>The font size of Bill of Material content</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BillOfMaterialContent.py" line="97"/>
+        <source>The template for Bill of Material content</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BillOfMaterialContent.py" line="108"/>
+        <source>The width of Bill of Material content</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BillOfMaterialContent.py" line="120"/>
+        <source>The height of Bill of Material content</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BillOfMaterialContent.py" line="132"/>
+        <source>The left offset of Bill of Material content</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BillOfMaterialContent.py" line="144"/>
+        <source>The top offset of Bill of Material content</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BillOfMaterialContent.py" line="156"/>
+        <source>The minimum right offset of Bill of Material content</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BillOfMaterialContent.py" line="168"/>
+        <source>The minimum bottom offset of Bill of Material content</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BillOfMaterialContent.py" line="180"/>
+        <source>The maximum width of Bill of Material content</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BillOfMaterialContent.py" line="192"/>
+        <source>The maximum height of Bill of Material content</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BillOfMaterialContent.py" line="204"/>
+        <source>The preferred column width of table of Bill of Material content</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BillOfMaterialContent.py" line="217"/>
+        <source>The column width of table of Bill of Material content</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BillOfMaterialContent.py" line="230"/>
+        <source>The preferred row height of table of Bill of Material content</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/BillOfMaterialContent.py" line="243"/>
+        <source>The row height of table of Bill of Material content</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../UShapeRebar.py" line="430"/>
         <source>Front cover of rebar</source>
         <translation type="unfinished"></translation>
@@ -610,6 +3349,711 @@
     <message>
         <location filename="../UShapeRebar.py" line="479"/>
         <source>Shape of rebar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="517"/>
+        <source>Column Front Cover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="529"/>
+        <source>Column Left Cover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="541"/>
+        <source>Column Right Cover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="553"/>
+        <source>Column Rear Cover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="565"/>
+        <source>Tie Top Cover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="577"/>
+        <source>Tie Bottom Cover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="589"/>
+        <source>Tie Bent Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="601"/>
+        <source>Tie Extension Factor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="613"/>
+        <source>Tie Diameter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="625"/>
+        <source>Tie Number Spacing Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="637"/>
+        <source>Tie Amount Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="649"/>
+        <source>Tie Spacing Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="661"/>
+        <source>Column Main Rebar&apos;s Diameter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="673"/>
+        <source>Column Main Rebars TopOffset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="685"/>
+        <source>Column Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="697"/>
+        <source>Column Length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="709"/>
+        <source>X Direction Column Number Spacing Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="721"/>
+        <source>X Direction Column Amount Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="733"/>
+        <source>X Direction Column Spacing Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="745"/>
+        <source>Y Direction Column Number Spacing Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="757"/>
+        <source>Y Direction Column Amount Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="769"/>
+        <source>Y Direction Column Spacing Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="781"/>
+        <source>Main Rebars Types</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="796"/>
+        <source>Main L-shape Rebars Hook Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="817"/>
+        <source>Main L-shape Rebars Hook Extend Along</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="829"/>
+        <source>Main L-shape Rebars Rounding </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="841"/>
+        <source>Main L-shape Rebars Hook Extension</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="853"/>
+        <source>Secoundery Rebars Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="865"/>
+        <source>Secoundery Rebars Top Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="877"/>
+        <source>Secoundery Rebars Number Diameter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="892"/>
+        <source>Secoundery Rebars type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="907"/>
+        <source>Secoundery L-Shape Rebar Hook Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="922"/>
+        <source>Secoundery L-Shape Rebar Hook Rounding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="934"/>
+        <source>Secoundery L-Shape Rebar Hook Extension</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="1617"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="121"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="94"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="81"/>
+        <source>List of reinforcement groups</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="62"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="132"/>
+        <source>Mesh Cover Along for slab reinforcement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="74"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="144"/>
+        <source>Facename</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="85"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="155"/>
+        <source>Structure</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="96"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="166"/>
+        <source>Parallel Rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="109"/>
+        <source>Parallel Distribution Rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="122"/>
+        <source>Cross Distribution Rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="135"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="179"/>
+        <source>Cross Rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="149"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="193"/>
+        <source>Rebar Type for parallel rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="166"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="210"/>
+        <source>Front Cover for parallel rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="178"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="222"/>
+        <source>Rear Cover for parallel rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="190"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="234"/>
+        <source>Left Cover for parallel rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="202"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="246"/>
+        <source>Right Cover for parallel rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="214"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="258"/>
+        <source>Top Cover for parallel rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="226"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="270"/>
+        <source>Bottom Cover for parallel rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="238"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="282"/>
+        <source>Diameter for parallel rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="250"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="294"/>
+        <source>Amount or Spacing Check for parallel rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="262"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="306"/>
+        <source>Rebar&apos;s Amount Value for parallel rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="274"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="318"/>
+        <source>Spacing Value for parallel rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="286"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="330"/>
+        <source>Rounding for parallel rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="298"/>
+        <source>Bent Bar Length for parallel bent shape rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="310"/>
+        <source>Bent Bar Angle for parallel bent shape rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="322"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="342"/>
+        <source>L-Shape Hook Orintation for parallel L-Shape rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="334"/>
+        <source>Distribution Rebars Check for parallel distribution rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="346"/>
+        <source>Diameter for parallel distribution rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="358"/>
+        <source>Amount or Spacing Check for parallel distribution rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="370"/>
+        <source>Rebar&apos;s amount for parallel distribution rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="382"/>
+        <source>Rebars Spacing for parallel distribution rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="395"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="355"/>
+        <source>Rebar Type for cross rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="412"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="372"/>
+        <source>Front Cover for cross rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="424"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="384"/>
+        <source>Rear Cover for cross rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="436"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="396"/>
+        <source>Left Cover for cross rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="448"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="408"/>
+        <source>Right Cover for cross rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="460"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="420"/>
+        <source>Top Cover for cross rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="472"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="432"/>
+        <source>Bottom Cover for cross rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="484"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="444"/>
+        <source>Diameter for cross rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="496"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="456"/>
+        <source>Amount or Spacing Check for cross rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="508"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="468"/>
+        <source>Rebar&apos;s Amount Value for cross rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="520"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="480"/>
+        <source>Spacing Value for cross rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="532"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="492"/>
+        <source>Rounding for cross rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="544"/>
+        <source>Bent Bar Length for cross bent shape rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="556"/>
+        <source>Bent Bar Angle for cross bent shape rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="568"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="504"/>
+        <source>L-Shape Hook Orintation for cross L-Shape rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="580"/>
+        <source>Distribution Rebars check for cross distribution rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="592"/>
+        <source>Rebars Diameter for cross distribution rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="604"/>
+        <source>Amount or Spacing check for cross distribution rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="616"/>
+        <source>Rebars amount for cross distribution rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="628"/>
+        <source>Spacing value for cross distribution rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/SlabReinforcementObject.py" line="640"/>
+        <location filename="../FootingReinforcement/FootingReinforcementObject.py" line="108"/>
+        <source>Check if make or update required for slab reinforcement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDimensioning.py" line="126"/>
+        <source>The parent ReinforcementDrawingView object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDimensioning.py" line="137"/>
+        <source>The ArchRebar object to generate dimensioning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDimensioning.py" line="148"/>
+        <source>The way points type of dimension line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDimensioning.py" line="159"/>
+        <source>The way points of dimension line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDimensioning.py" line="171"/>
+        <source>The position type of dimension text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDimensioning.py" line="186"/>
+        <source>The dimension label format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDimensioning.py" line="198"/>
+        <source>The font family of dimension text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDimensioning.py" line="210"/>
+        <source>The font size of dimension text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDimensioning.py" line="222"/>
+        <source>The stroke width of dimension line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDimensioning.py" line="234"/>
+        <source>The stroke style of dimension line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDimensioning.py" line="252"/>
+        <source>The color of dimension line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDimensioning.py" line="264"/>
+        <source>The color of dimension text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDimensioning.py" line="276"/>
+        <source>The start symbol of dimension line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDimensioning.py" line="294"/>
+        <source>The end symbol of dimension line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDimensioning.py" line="312"/>
+        <source>The mid points symbol of dimension line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDimensioning.py" line="329"/>
+        <source>The left offset for automated reinforcement dimensioning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDimensioning.py" line="340"/>
+        <source>The right offset for automated reinforcement dimensioning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDimensioning.py" line="352"/>
+        <source>The top offset for automated reinforcement dimensioning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDimensioning.py" line="363"/>
+        <source>The bottom offset for automated reinforcement dimensioning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDimensioning.py" line="375"/>
+        <source>The dimension line start symbol, in case of single rebar is visible</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDimensioning.py" line="395"/>
+        <source>The dimension line end symbol, in case of single rebar is visible</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDimensioning.py" line="415"/>
+        <source>The dimension line start symbol, in case of multiple rebars are visible</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDimensioning.py" line="435"/>
+        <source>The dimension line end symbol, in case of multiple rebars are visible</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDimensioning.py" line="453"/>
+        <source>True if dimension lines to be outside of reinforcement drawing for automated reinforcement dimensioning, in case of single rebar is visible</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDimensioning.py" line="467"/>
+        <source>True if dimension lines to be outside of reinforcement drawing for automated reinforcement dimensioning, in case of multiple rebars are visible</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDimensioning.py" line="481"/>
+        <source>The position type of dimension text, in case of single rebar is visible</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDimensioning.py" line="500"/>
+        <source>The position type of dimension text, in case of multiple rebars are visible</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingView.py" line="70"/>
+        <source>The structure object acting as Host for rebars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingView.py" line="81"/>
+        <source>The list of rebar objects to be included in drawing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingView.py" line="92"/>
+        <source>The reinforcement drawing view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingView.py" line="103"/>
+        <source>The position type of Reinforcement Drawing on Template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingView.py" line="115"/>
+        <source>The stroke width of rebars in Reinforcement Drawing svg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingView.py" line="127"/>
+        <source>The color style of rebars in Reinforcement Drawing svg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingView.py" line="139"/>
+        <source>The color of rebars in Reinforcement Drawing svg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingView.py" line="151"/>
+        <source>The stroke width of structure in Reinforcement Drawing svg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingView.py" line="164"/>
+        <source>The color style of structure in Reinforcement Drawing svg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingView.py" line="176"/>
+        <source>The color of structure in Reinforcement Drawing svg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingView.py" line="188"/>
+        <source>The template for Reinforcement Drawing view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingView.py" line="199"/>
+        <source>The width of Reinforcement Drawing view svg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingView.py" line="212"/>
+        <source>The height of Reinforcement Drawing view svg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingView.py" line="225"/>
+        <source>The left offset of Reinforcement Drawing view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingView.py" line="237"/>
+        <source>The top offset of Reinforcement Drawing view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingView.py" line="249"/>
+        <source>The minimum right offset of Reinforcement Drawing view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingView.py" line="261"/>
+        <source>The minimum bottom offset of Reinforcement Drawing view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingView.py" line="273"/>
+        <source>The maximum width of Reinforcement Drawing view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingView.py" line="285"/>
+        <source>The maximum height of Reinforcement Drawing view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingView.py" line="297"/>
+        <source>The list of visible rebar objects in drawing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingView.py" line="313"/>
+        <source>The left offset for each new ReinforcementDimensioning object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingView.py" line="328"/>
+        <source>The right offset for each new ReinforcementDimensioning object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingView.py" line="343"/>
+        <source>The top offset for each new ReinforcementDimensioning object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/ReinforcementDrawingView.py" line="358"/>
+        <source>The bottom offset for each new ReinforcementDimensioning object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -679,6 +4123,26 @@
 <context>
     <name>RebarAddon</name>
     <message>
+        <location filename="../BillOfMaterial/EditSVGConfiguration.py" line="70"/>
+        <source>BOM - Edit SVG Configurations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BillOfMaterial/MainBillOfMaterial.py" line="90"/>
+        <source>Rebars Bill Of Material</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/MainColumnReinforcement.py" line="81"/>
+        <source>Column Reinforcement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ColumnReinforcement/RebarNumberDiameter.py" line="45"/>
+        <source>Rebar Number Diameter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../BentShapeRebar.py" line="181"/>
         <source>Bent Shape Rebar</source>
         <translation type="unfinished"></translation>
@@ -733,10 +4197,56 @@
     </message>
 </context>
 <context>
+    <name>RebarWorkbench</name>
+    <message>
+        <location filename="../FootingReinforcement/MainFootingReinforcement.py" line="59"/>
+        <source>Footing Reinforcement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SlabReinforcement/MainSlabReinforcement.py" line="58"/>
+        <source>Slab Reinforcement</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ReinforcementWorkbench</name>
+    <message>
+        <location filename="../BarBendingSchedule/MainBarBendingSchedule.py" line="130"/>
+        <source>Bar Bending Schedule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarShapeCutList/MainRebarShapeCutList.py" line="98"/>
+        <source>Rebar Shape Cut List</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ReinforcementDrawing/MainReinforcementDrawingDimensioning.py" line="240"/>
+        <source>Reinforcement Drawing Dimensioning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../InitGui.py" line="41"/>
+        <source>Reinforcement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../InitGui.py" line="42"/>
+        <source>Create Building Reinforcement</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Reinforcement_BarBendingSchedule</name>
     <message>
         <location filename="../RebarTools.py" line="411"/>
         <source>Bar Bending Schedule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarTools.py" line="420"/>
+        <source>Generate Bar Bending Schedule</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -747,12 +4257,22 @@
         <source>Rebar Shape Cut List</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../RebarTools.py" line="389"/>
+        <source>Generate Rebar Shape Cut List</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Reinforcement_BeamRebars</name>
     <message>
         <location filename="../RebarTools.py" line="262"/>
         <source>Beam Reinforcement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarTools.py" line="265"/>
+        <source>Creates a Beam Reinforcement from the selected face of the Structural element.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -763,12 +4283,22 @@
         <source>Bent-Shape Rebar</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../RebarTools.py" line="175"/>
+        <source>Creates a BentShape bar reinforcement from the selected face of the Structural element.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Reinforcement_BillOfMaterial</name>
     <message>
         <location filename="../RebarTools.py" line="349"/>
         <source>Rebar Bill Of Material</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarTools.py" line="358"/>
+        <source>Generate Rebars Bill Of Material</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -779,12 +4309,35 @@
         <source>Column Reinforcement</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../RebarTools.py" line="236"/>
+        <source>Creates a Column Reinforcement from the selected face of the Structural element.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Reinforcement_DrawingDimensioning</name>
+    <message>
+        <location filename="../RebarTools.py" line="448"/>
+        <source>Reinforcement Drawing Dimensioning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarTools.py" line="452"/>
+        <source>Generate Reinforcement Drawing Dimensioning</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Reinforcement_FootingRebars</name>
     <message>
         <location filename="../RebarTools.py" line="320"/>
         <source>Footing Reinforcement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarTools.py" line="329"/>
+        <source>Creates a Footing Reinforcement from the selected face of the Structural element.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -795,12 +4348,22 @@
         <source>Helical Rebar</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../RebarTools.py" line="207"/>
+        <source>Creates a Helical bar reinforcement from the selected face of the Structural element.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Reinforcement_LShapeRebar</name>
     <message>
         <location filename="../RebarTools.py" line="108"/>
         <source>L-Shape Rebar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarTools.py" line="111"/>
+        <source>Creates a L-Shape bar reinforcement from the selected face of the Structural element.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -811,12 +4374,22 @@
         <source>Slab Reinforcement</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../RebarTools.py" line="297"/>
+        <source>Creates a Slab Reinforcement from the selected face of the Structural element.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Reinforcement_StirrupRebar</name>
     <message>
         <location filename="../RebarTools.py" line="140"/>
         <source>Stirrup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarTools.py" line="143"/>
+        <source>Creates a Stirrup bar reinforcement from the selected face of the Structural element.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -827,12 +4400,22 @@
         <source>Straight Rebar</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../RebarTools.py" line="47"/>
+        <source>Creates a Straight bar reinforcement from the selected face of the Structural element.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Reinforcement_UShapeRebar</name>
     <message>
         <location filename="../RebarTools.py" line="76"/>
         <source>U-Shape Rebar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../RebarTools.py" line="79"/>
+        <source>Creates a U-Shape bar reinforcement from the selected face of the Structural element.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/update_translation.sh
+++ b/translations/update_translation.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+
+# --------------------------------------------------------------------------------------------------
+#
+# Update translation files
+#
+# Supported locales on FreeCAD <2024-01-20, FreeCADGui.supportedLocales(), total=40>:
+# 	{'English': 'en', 'Afrikaans': 'af', 'Arabic': 'ar', 'Basque': 'eu', 'Belarusian': 'be',
+# 	'Bulgarian': 'bg', 'Catalan': 'ca', 'Chinese Simplified': 'zh-CN',
+# 	'Chinese Traditional': 'zh-TW', 'Croatian': 'hr', 'Czech': 'cs', 'Dutch': 'nl',
+# 	'Filipino': 'fil', 'Finnish': 'fi', 'French': 'fr', 'Galician': 'gl', 'Georgian': 'ka',
+# 	'German': 'de', 'Greek': 'el', 'Hungarian': 'hu', 'Indonesian': 'id', 'Italian': 'it',
+# 	'Japanese': 'ja', 'Kabyle': 'kab', 'Korean': 'ko', 'Lithuanian': 'lt', 'Norwegian': 'no',
+# 	'Polish': 'pl', 'Portuguese': 'pt-PT', 'Portuguese, Brazilian': 'pt-BR', 'Romanian': 'ro',
+# 	'Russian': 'ru', 'Serbian': 'sr', 'Serbian, Latin': 'sr-CS', 'Slovak': 'sk',
+# 	'Slovenian': 'sl', 'Spanish': 'es-ES', 'Spanish, Argentina': 'es-AR', 'Swedish': 'sv-SE',
+# 	'Turkish': 'tr', 'Ukrainian': 'uk', 'Valencian': 'val-ES', 'Vietnamese': 'vi'}
+#
+# NOTE: WORKFLOW
+# 0. Install Qt tools
+# 	Debian-based (e.g., Ubuntu): $ sudo apt-get install qttools5-dev-tools pyqt6-dev-tools
+# 	Fedora-based: $ sudo dnf install qt6-linguist qt6-devel
+# 	Arch-based: $ sudo pacman -S qt6-tools python-pyqt6
+# 1. Make the script executable
+# 	$ chmod +x update_translation.sh
+# 2. Execute the script passing the locale code as first parameter
+# 	The script has to be executed within the `resources/translations` directory
+# 	Only update the files you're translating!
+# 	$ ./update_translation.sh es-ES
+# 3. Do the translation via Qt Linguist and use `File>Release`
+# 4. If releasing with the script execute the script passing the locale code as first parameter
+# 	and use '-r' flag next
+# 	$ ./update_translation.sh es-ES -r
+#
+# The usage of `pylupdate6` is preferred over 'pylupdate5' when extracting text strings from
+# 	Python files.
+#
+# --------------------------------------------------------------------------------------------------
+
+supported_locales=(
+	"en" "af" "ar" "eu" "be" "bg" "ca" "zh-CN" "zh-TW" "hr"
+	"cs" "nl" "fil" "fi" "fr" "gl" "ka" "de" "el" "hu"
+	"id" "it" "ja" "kab" "ko" "lt" "no" "pl" "pt-PT" "pt-BR"
+	"ro" "ru" "sr" "es-ES" "es-AR" "sv-SE" "tr" "uk" "val-ES" "vi"
+)
+
+is_locale_supported() {
+	local locale="$1"
+	for supported_locale in "${supported_locales[@]}"; do
+		if [[ "$supported_locale" == "$locale" ]]; then
+			return 0
+		fi
+	done
+	return 1
+}
+
+get_strings() {
+	# Get translatable strings from Qt Designer files
+	lupdate ../BarBendingSchedule/*.ui ../BillOfMaterial/*.ui \
+		../ColumnReinforcement/*.ui ../FootingReinforcement/*.ui \
+		../RebarShapeCutList/*.ui ../ReinforcementDrawing/*.ui \
+		../SlabReinforcement/*.ui ../*.ui \
+		-ts uifiles.ts -no-obsolete
+	# Get translatable strings from Python files
+	pylupdate6 ../BarBendingSchedule/*.py ../BillOfMaterial/*.py \
+		../ColumnReinforcement/*.py ../FootingReinforcement/*.py \
+		../RebarShapeCutList/*.py ../ReinforcementDrawing/*.py \
+		../SlabReinforcement/*.py ../*.py \
+		-ts pyfiles.ts
+}
+
+delete_files() {
+	# Delete files that are no longer needed
+	rm uifiles.ts
+	rm pyfiles.ts
+	rm -f _${WB}.ts
+}
+
+add_new_locale() {
+	echo -e "\033[1;33m\n\t<<< Creating '${WB}_${LOCALE}.ts' file >>>\n\033[m"
+	get_strings
+	# Join strings from Qt Designer and Python files into temp file
+	lconvert -i uifiles.ts pyfiles.ts -o _${WB}.ts
+	# Add generic file
+	lconvert -i _${WB}.ts -o ${WB}.ts
+	# Add specified locale file
+	lconvert -source-language en -target-language $LOCALE \
+		-i _${WB}.ts -o ${WB}_${LOCALE}.ts
+}
+
+update_locale() {
+	echo -e "\033[1;32m\n\t<<< Updating '${WB}_${LOCALE}.ts' file >>>\n\033[m"
+	get_strings
+	# Join strings from Qt Designer and Python files
+	lconvert -i uifiles.ts pyfiles.ts -o _${WB}.ts
+	# Join newly created file with older file (-no-obsolete)
+	# Update generic file
+	lconvert -i _${WB}.ts ${WB}.ts -o ${WB}.ts
+	# Update specified locale file
+	lconvert -source-language en -target-language $LOCALE \
+		-i _${WB}.ts ${WB}_${LOCALE}.ts -o ${WB}_${LOCALE}.ts
+}
+
+release_translation() {
+	# Release translation (creation of *.qm file from *.ts file)
+	lrelease ${WB}_${LOCALE}.ts
+}
+
+# Main function ------------------------------------------------------------------------------------
+
+WB="Reinforcement"
+LOCALE="$1"
+
+if is_locale_supported "$LOCALE"; then
+	if [ "$2" == "-r" ]; then
+		release_translation
+	else
+		if [ ! -f "${WB}_${LOCALE}.ts" ]; then
+			add_new_locale
+		else
+			update_locale
+		fi
+		delete_files
+	fi
+else
+	echo "Verify your language code. Case sensitive."
+	echo "If it's correct ask a maintainer to add support for your language on FreeCAD."
+fi


### PR DESCRIPTION
I don't know what is the current method to maintain the translations on this WB but it seems that there are some problems with some strings, so this script aims to fix that.

- Add bash script to include marked strings on translation files (*.ts)
  - Read from `.ui` files
  - Read from `.py` files

Fix:
- https://github.com/FreeCAD/FreeCAD-translations/issues/135
- https://github.com/FreeCAD/FreeCAD-translations/issues/136

I made some tests and can confirm that the tooltips now appear.

**Edit**: Make WB name and tooltip translatable. Move `FreeCADGui.addLanguagePath()` to top to make translated WB name take effect.
