### PR TITLE
Hidden groupbox-headers in ReinforcementDrawingDimensioning-dialogs

### DIFF
--- a/ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions1.ui
+++ b/ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions1.ui
@@ -32,7 +32,7 @@
        <number>0</number>
       </property>
       <property name="topMargin">
-       <number>0</number>
+       <number>8</number>
       </property>
       <property name="rightMargin">
        <number>0</number>
@@ -168,7 +168,7 @@
        <number>0</number>
       </property>
       <property name="topMargin">
-       <number>0</number>
+       <number>8</number>
       </property>
       <property name="rightMargin">
        <number>0</number>

--- a/ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui
+++ b/ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions2.ui
@@ -32,7 +32,7 @@
        <number>0</number>
       </property>
       <property name="topMargin">
-       <number>0</number>
+       <number>8</number>
       </property>
       <property name="rightMargin">
        <number>0</number>
@@ -250,7 +250,7 @@
        <number>0</number>
       </property>
       <property name="topMargin">
-       <number>0</number>
+       <number>8</number>
       </property>
       <property name="rightMargin">
        <number>0</number>

--- a/ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions3.ui
+++ b/ReinforcementDrawing/ReinforcementDrawingDimensioning_Dimensions3.ui
@@ -32,7 +32,7 @@
        <number>0</number>
       </property>
       <property name="topMargin">
-       <number>0</number>
+       <number>8</number>
       </property>
       <property name="rightMargin">
        <number>0</number>
@@ -247,7 +247,7 @@
        <number>0</number>
       </property>
       <property name="topMargin">
-       <number>0</number>
+       <number>8</number>
       </property>
       <property name="rightMargin">
        <number>0</number>

--- a/ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui
+++ b/ReinforcementDrawing/ReinforcementDrawingDimensioning_Drawing.ui
@@ -24,7 +24,7 @@
        <number>0</number>
       </property>
       <property name="topMargin">
-       <number>0</number>
+       <number>8</number>
       </property>
       <property name="rightMargin">
        <number>0</number>

--- a/ReinforcementDrawing/ReinforcementDrawingDimensioning_Shapes.ui
+++ b/ReinforcementDrawing/ReinforcementDrawingDimensioning_Shapes.ui
@@ -32,7 +32,7 @@
        <number>0</number>
       </property>
       <property name="topMargin">
-       <number>0</number>
+       <number>8</number>
       </property>
       <property name="rightMargin">
        <number>0</number>
@@ -199,7 +199,7 @@
        <number>0</number>
       </property>
       <property name="topMargin">
-       <number>0</number>
+       <number>8</number>
       </property>
       <property name="rightMargin">
        <number>0</number>


### PR DESCRIPTION
This pull request somehow solves the issue with the invisible groupbox header (part 2 of issue #214 ) for the "Reinforcement Drawing Dimensioning"-dialogs. I could notice the issue only for the FreeCAD-dev on a Windows11 machine. Here the scrollarea within the groupbox seems to hide the header of the groupbox.